### PR TITLE
Make quick-guide pages full-width on desktop

### DIFF
--- a/caesarean-guide.html
+++ b/caesarean-guide.html
@@ -76,6 +76,37 @@
 
   .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
   .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
+  /* ===== Desktop / web view: full-width page with a centered content column ===== */
+  @media (min-width: 768px){
+    body{ padding:0; }
+    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
+
+    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
+    .phone > *{
+      padding-left: max(24px, calc((100% - 760px) / 2));
+      padding-right: max(24px, calc((100% - 760px) / 2));
+    }
+    /* inset coloured cards become full-bleed bands too */
+    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
+    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
+    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
+
+    /* larger, web-friendly typography */
+    .head{ padding-top:52px; }
+    .head .logo-badge{ width:80px; height:80px; }
+    .head h1{ font-size:34px; line-height:1.2; }
+    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
+    .cta h3{ font-size:20px; }
+    .cta p{ font-size:14px; }
+    /* store buttons: natural badge size instead of stretching full width */
+    .stores{ gap:12px; justify-content:flex-start; }
+    .store{ flex:0 0 auto; width:210px; }
+    .sec-title{ font-size:22px; }
+    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
+    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
+    .disc{ font-size:12px; }
+  }
+
 </style>
 </head>
 <body>

--- a/during-labour-guide.html
+++ b/during-labour-guide.html
@@ -72,6 +72,37 @@
 
   .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
   .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
+  /* ===== Desktop / web view: full-width page with a centered content column ===== */
+  @media (min-width: 768px){
+    body{ padding:0; }
+    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
+
+    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
+    .phone > *{
+      padding-left: max(24px, calc((100% - 760px) / 2));
+      padding-right: max(24px, calc((100% - 760px) / 2));
+    }
+    /* inset coloured cards become full-bleed bands too */
+    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
+    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
+    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
+
+    /* larger, web-friendly typography */
+    .head{ padding-top:52px; }
+    .head .logo-badge{ width:80px; height:80px; }
+    .head h1{ font-size:34px; line-height:1.2; }
+    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
+    .cta h3{ font-size:20px; }
+    .cta p{ font-size:14px; }
+    /* store buttons: natural badge size instead of stretching full width */
+    .stores{ gap:12px; justify-content:flex-start; }
+    .store{ flex:0 0 auto; width:210px; }
+    .sec-title{ font-size:22px; }
+    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
+    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
+    .disc{ font-size:12px; }
+  }
+
 </style>
 </head>
 <body>

--- a/epidural-guide.html
+++ b/epidural-guide.html
@@ -91,6 +91,37 @@
 
   .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
   .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
+  /* ===== Desktop / web view: full-width page with a centered content column ===== */
+  @media (min-width: 768px){
+    body{ padding:0; }
+    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
+
+    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
+    .phone > *{
+      padding-left: max(24px, calc((100% - 760px) / 2));
+      padding-right: max(24px, calc((100% - 760px) / 2));
+    }
+    /* inset coloured cards become full-bleed bands too */
+    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
+    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
+    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
+
+    /* larger, web-friendly typography */
+    .head{ padding-top:52px; }
+    .head .logo-badge{ width:80px; height:80px; }
+    .head h1{ font-size:34px; line-height:1.2; }
+    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
+    .cta h3{ font-size:20px; }
+    .cta p{ font-size:14px; }
+    /* store buttons: natural badge size instead of stretching full width */
+    .stores{ gap:12px; justify-content:flex-start; }
+    .store{ flex:0 0 auto; width:210px; }
+    .sec-title{ font-size:22px; }
+    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
+    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
+    .disc{ font-size:12px; }
+  }
+
 </style>
 </head>
 <body>

--- a/family-support-guide.html
+++ b/family-support-guide.html
@@ -67,6 +67,37 @@
 
   .disc{padding:14px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
   .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#b3a99c;}
+  /* ===== Desktop / web view: full-width page with a centered content column ===== */
+  @media (min-width: 768px){
+    body{ padding:0; }
+    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
+
+    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
+    .phone > *{
+      padding-left: max(24px, calc((100% - 760px) / 2));
+      padding-right: max(24px, calc((100% - 760px) / 2));
+    }
+    /* inset coloured cards become full-bleed bands too */
+    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
+    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
+    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
+
+    /* larger, web-friendly typography */
+    .head{ padding-top:52px; }
+    .head .logo-badge{ width:80px; height:80px; }
+    .head h1{ font-size:34px; line-height:1.2; }
+    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
+    .cta h3{ font-size:20px; }
+    .cta p{ font-size:14px; }
+    /* store buttons: natural badge size instead of stretching full width */
+    .stores{ gap:12px; justify-content:flex-start; }
+    .store{ flex:0 0 auto; width:210px; }
+    .sec-title{ font-size:22px; }
+    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
+    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
+    .disc{ font-size:12px; }
+  }
+
 </style>
 </head>
 <body>

--- a/partner-support-guide.html
+++ b/partner-support-guide.html
@@ -62,6 +62,37 @@
 
   .disc{padding:14px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
   .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#b3a99c;}
+  /* ===== Desktop / web view: full-width page with a centered content column ===== */
+  @media (min-width: 768px){
+    body{ padding:0; }
+    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
+
+    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
+    .phone > *{
+      padding-left: max(24px, calc((100% - 760px) / 2));
+      padding-right: max(24px, calc((100% - 760px) / 2));
+    }
+    /* inset coloured cards become full-bleed bands too */
+    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
+    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
+    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
+
+    /* larger, web-friendly typography */
+    .head{ padding-top:52px; }
+    .head .logo-badge{ width:80px; height:80px; }
+    .head h1{ font-size:34px; line-height:1.2; }
+    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
+    .cta h3{ font-size:20px; }
+    .cta p{ font-size:14px; }
+    /* store buttons: natural badge size instead of stretching full width */
+    .stores{ gap:12px; justify-content:flex-start; }
+    .store{ flex:0 0 auto; width:210px; }
+    .sec-title{ font-size:22px; }
+    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
+    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
+    .disc{ font-size:12px; }
+  }
+
 </style>
 </head>
 <body>

--- a/post-delivery-guide.html
+++ b/post-delivery-guide.html
@@ -178,6 +178,37 @@
     color:var(--muted);text-align:center;
   }
   .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
+  /* ===== Desktop / web view: full-width page with a centered content column ===== */
+  @media (min-width: 768px){
+    body{ padding:0; }
+    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
+
+    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
+    .phone > *{
+      padding-left: max(24px, calc((100% - 760px) / 2));
+      padding-right: max(24px, calc((100% - 760px) / 2));
+    }
+    /* inset coloured cards become full-bleed bands too */
+    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
+    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
+    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
+
+    /* larger, web-friendly typography */
+    .head{ padding-top:52px; }
+    .head .logo-badge{ width:80px; height:80px; }
+    .head h1{ font-size:34px; line-height:1.2; }
+    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
+    .cta h3{ font-size:20px; }
+    .cta p{ font-size:14px; }
+    /* store buttons: natural badge size instead of stretching full width */
+    .stores{ gap:12px; justify-content:flex-start; }
+    .store{ flex:0 0 auto; width:210px; }
+    .sec-title{ font-size:22px; }
+    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
+    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
+    .disc{ font-size:12px; }
+  }
+
 </style>
 </head>
 <body>

--- a/pre-labour-prep-guide.html
+++ b/pre-labour-prep-guide.html
@@ -156,6 +156,37 @@
 
   .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
   .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
+  /* ===== Desktop / web view: full-width page with a centered content column ===== */
+  @media (min-width: 768px){
+    body{ padding:0; }
+    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
+
+    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
+    .phone > *{
+      padding-left: max(24px, calc((100% - 760px) / 2));
+      padding-right: max(24px, calc((100% - 760px) / 2));
+    }
+    /* inset coloured cards become full-bleed bands too */
+    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
+    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
+    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
+
+    /* larger, web-friendly typography */
+    .head{ padding-top:52px; }
+    .head .logo-badge{ width:80px; height:80px; }
+    .head h1{ font-size:34px; line-height:1.2; }
+    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
+    .cta h3{ font-size:20px; }
+    .cta p{ font-size:14px; }
+    /* store buttons: natural badge size instead of stretching full width */
+    .stores{ gap:12px; justify-content:flex-start; }
+    .store{ flex:0 0 auto; width:210px; }
+    .sec-title{ font-size:22px; }
+    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
+    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
+    .disc{ font-size:12px; }
+  }
+
 </style>
 </head>
 <body>


### PR DESCRIPTION
Add a desktop media query so the share-card guides render as full-width web pages (full-bleed hero/CTA bands, centered content column, larger type, and right-sized store buttons top and bottom) instead of a fixed phone frame. Mobile phone-card layout is unchanged.