### PR TITLE
Redesign guide pages to match existing guides and unify the hub grid

### DIFF
--- a/caesarean-guide.html
+++ b/caesarean-guide.html
@@ -3,165 +3,76 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Your Caesarean Guide | MiGynae App</title>
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
-    <meta name="description" content="A quick caesarean (LSCS) guide: the essentials, recovering well, warning signs to watch for, and reassurance that it is still your birth.">
-    <link rel="canonical" href="https://migynaeapp.com/caesarean-guide.html">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://migynaeapp.com/caesarean-guide.html">
-    <meta property="og:title" content="Your Caesarean Guide | MiGynae App">
-    <meta property="og:description" content="A quick caesarean (LSCS) guide: the essentials, recovering well, warning signs to watch for, and reassurance that it is still your birth.">
-    <meta property="og:image" content="https://migynaeapp.com/images/logo.webp">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Your Caesarean Guide | MiGynae App">
-    <meta name="twitter:description" content="A quick caesarean (LSCS) guide: the essentials, recovering well, warning signs to watch for, and reassurance that it is still your birth.">
-<style>
-  :root{
-    --green:#2f4a3d; --cream:#faf6ee; --card:#ffffff; --ink:#2c2622; --muted:#6b655d; --line:#e7ded0;
-    --gold:#c8974a; --rose:#b6524c; --rose-bg:#fbeeed; --ok:#3f7a5a; --ok-bg:#eef5f0;
-    --serif:Georgia,'Times New Roman',serif;      /* -> Lora */
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; /* -> DM Sans */
-  }
-  *{box-sizing:border-box;margin:0;padding:0;}
-  body{background:#d9d3c7;font-family:var(--sans);color:var(--ink);display:flex;justify-content:center;padding:24px 12px;-webkit-font-smoothing:antialiased;}
-  .phone{width:390px;max-width:100%;background:var(--cream);border-radius:28px;overflow:hidden;box-shadow:0 12px 40px rgba(0,0,0,.18);}
-
-  .cta{background:var(--green);color:#fff;padding:18px 20px 20px;}
-  .cta.bottom{padding:22px 20px 26px;}
-  .cta h3{font-family:var(--serif);font-weight:600;font-size:16px;line-height:1.35;margin:6px 0 4px;}
-  .cta p{font-size:12.5px;color:#d9e5df;line-height:1.5;margin-bottom:14px;}
-  .stores{display:flex;gap:8px;}
-  .store{flex:1;display:flex;align-items:center;gap:8px;background:#fff;color:var(--green);text-decoration:none;padding:9px 10px;border-radius:11px;font-size:11px;font-weight:600;line-height:1.2;}
-  .store .ico{font-size:16px;line-height:1;}
-  .store small{display:block;font-size:8.5px;font-weight:500;color:var(--muted);letter-spacing:.3px;}
-
-  .logo-badge{width:40px;height:40px;border-radius:50%;background:#fff;padding:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,.12);}
-  .logo-badge img{width:100%;height:100%;object-fit:contain;border-radius:50%;}
-  .head .logo-badge{width:64px;height:64px;margin:0 auto 14px;}
-
-  .head{padding:22px 22px 6px;text-align:center;}
-  .kicker{font-size:10.5px;letter-spacing:1.6px;text-transform:uppercase;color:var(--gold);font-weight:700;margin-bottom:8px;}
-  .head h1{font-family:var(--serif);font-weight:600;font-size:23px;line-height:1.25;color:var(--green);}
-  .head .sub{font-size:13px;color:var(--muted);line-height:1.55;margin-top:10px;}
-
-  .sec{padding:20px 22px 4px;}
-  .sec-title{font-family:var(--serif);font-size:17px;font-weight:600;color:var(--green);margin-bottom:12px;}
-
-  .row{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;margin-bottom:10px;}
-  .row p{font-size:13px;line-height:1.55;color:var(--ink);}
-  .row p b{color:var(--green);}
-  .row ul{list-style:none;margin-top:2px;}
-  .row li{font-size:12.5px;line-height:1.5;color:var(--ink);padding:5px 0 5px 16px;position:relative;}
-  .row li::before{content:"";position:absolute;left:0;top:9px;width:6px;height:6px;border-radius:50%;background:var(--gold);}
-  .row li b{color:var(--green);}
-
-  .warn{background:var(--rose-bg);border:1px solid #f0d3d1;border-radius:15px;padding:16px 16px 6px;}
-  .warn .wt{font-family:var(--serif);font-size:16px;font-weight:600;color:var(--rose);margin-bottom:4px;}
-  .warn .ws{font-size:11.5px;color:#9a5450;margin-bottom:12px;}
-  .warn ul{list-style:none;}
-  .warn li{font-size:13px;line-height:1.45;color:var(--ink);padding:7px 0 7px 24px;position:relative;border-top:1px solid #f2dcda;}
-  .warn li:first-child{border-top:none;}
-  .warn li::before{content:"•";color:var(--rose);font-weight:700;position:absolute;left:8px;top:6px;font-size:15px;}
-
-  .soft{background:var(--ok-bg);border:1px solid #d9e7de;border-radius:13px;padding:14px 15px;}
-  .soft .st{font-family:var(--serif);font-size:15px;font-weight:600;color:var(--ok);margin-bottom:4px;}
-  .soft p{font-size:12.5px;line-height:1.6;color:var(--ink);}
-
-  .blogs{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;}
-  .blogs-h{font-size:12px;color:var(--muted);line-height:1.45;margin-bottom:10px;}
-  .blog-chip{display:inline-block;background:var(--ok-bg);color:var(--green);font-size:12px;font-weight:600;padding:7px 12px;border-radius:20px;margin:0 6px 6px 0;border:1px solid #d9e7de;}
-
-  .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
-  .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
-  /* ===== Desktop / web view: full-width page with a centered content column ===== */
-  @media (min-width: 768px){
-    body{ padding:0; }
-    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
-
-    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
-    .phone > *{
-      padding-left: max(24px, calc((100% - 760px) / 2));
-      padding-right: max(24px, calc((100% - 760px) / 2));
-    }
-    /* inset coloured cards become full-bleed bands too */
-    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
-    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
-    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
-
-    /* larger, web-friendly typography */
-    .head{ padding-top:52px; }
-    .head .logo-badge{ width:80px; height:80px; }
-    .head h1{ font-size:34px; line-height:1.2; }
-    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
-    .cta h3{ font-size:20px; }
-    .cta p{ font-size:14px; }
-    /* store buttons: natural badge size instead of stretching full width */
-    .stores{ gap:12px; justify-content:flex-start; }
-    .store{ flex:0 0 auto; width:210px; }
-    .sec-title{ font-size:22px; }
-    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
-    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
-    .disc{ font-size:12px; }
-  }
-
-</style>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<title>Your Caesarean Guide | MiGynae</title>
+<meta name="description" content="A caesarean (LSCS) guide: the essentials, recovering well, warning signs to watch for, and reassurance that it is still your birth.">
+<link rel="canonical" href="https://migynaeapp.com/caesarean-guide.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://migynaeapp.com/caesarean-guide.html">
+<meta property="og:title" content="Your Caesarean Guide | MiGynae">
+<meta property="og:description" content="A caesarean (LSCS) guide: the essentials, recovering well, warning signs to watch for, and reassurance that it is still your birth.">
+<meta property="og:image" content="https://migynaeapp.com/images/blog/labour-guide-banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Your Caesarean Guide | MiGynae">
+<meta name="twitter:description" content="A caesarean (LSCS) guide: the essentials, recovering well, warning signs to watch for, and reassurance that it is still your birth.">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="css/guide-page.css">
 </head>
 <body>
-<div class="phone">
 
-  <!-- TOP APP CTA -->
-  <div class="cta">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Planned or unplanned, the MiGynae App guides you through it</h3>
-    <p>Caesarean recovery, wound care, feeding and doctor-backed guidance in one place.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+  <div class="hero">
+    <div class="hero-inner">
+      <div class="hero-brand">Caesarean (LSCS)</div>
+      <h1>Your Caesarean Guide</h1>
+      <p class="hero-tagline">Whether it is planned or decided during labour, here are the essentials and must-knows, so you feel prepared and recover well.</p>
     </div>
   </div>
 
-  <!-- HEADER -->
-  <div class="head">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <div class="kicker">Caesarean (LSCS)</div>
-    <h1>Your Caesarean Guide</h1>
-    <p class="sub">Whether it is planned or decided during labour, here are the essentials and must-knows, so you feel prepared and recover well.</p>
+  <div class="download-bar">
+    <a class="dl-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Download on Play Store</a>
+    <a class="dl-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
   </div>
 
-  <!-- WHAT IT IS -->
-  <div class="sec">
-    <div class="sec-title">The essentials</div>
-    <div class="row">
-      <p><b>What it is.</b> A safe, very common surgery that delivers your baby through a cut in your lower tummy. You are usually <b>awake</b>, with a spinal injection that numbs you from the waist down, so you can meet your baby right away. A tube (catheter) drains your bladder and stays in for a while.</p>
-    </div>
-    <div class="row">
-      <p><b>Why it may be chosen.</b> Sometimes planned, sometimes decided in labour, for reasons like a breech baby, a low-lying placenta, the baby not coming down, or signs the baby should be born quickly. It is a decision made for <b>safety, never a failure</b> on your part.</p>
-    </div>
-  </div>
+  <div class="content">
 
-  <!-- RECOVERING WELL -->
-  <div class="sec">
-    <div class="sec-title">Recovering well: the must-knows</div>
-    <div class="row">
-      <ul>
-        <li>It is major surgery. Full healing takes about <b>6 weeks</b>, be patient with yourself.</li>
-        <li>Start <b>gentle movement early</b>, it helps prevent clots and speeds healing.</li>
-        <li>Support your stitches with a hand or pillow when you cough, laugh or get up.</li>
-        <li>Take pain relief as prescribed, you do not need to suffer.</li>
-        <li>Avoid heavy lifting, <b>nothing heavier than your baby</b> at first.</li>
-        <li>Feed in positions that keep the baby's weight off your wound.</li>
-      </ul>
+    <div class="intro-card">
+      A caesarean is a safe, very common way to bring your baby into the world. Knowing what happens and how to heal helps you recover with confidence.
     </div>
-  </div>
 
-  <!-- WARNING SIGNS -->
-  <div class="sec">
-    <div class="warn">
-      <div class="wt">🏥 When to call your doctor</div>
-      <div class="ws">After a caesarean, get help if you notice:</div>
+    <div class="section">
+      <div class="section-header"><div class="section-number">1</div><h2>The essentials</h2></div>
+      <div class="section-body">
+        <div class="card">
+          <div class="card-title"><i class="fas fa-baby"></i> What it is</div>
+          <p>A safe, very common surgery that delivers your baby through a cut in your lower tummy. You are usually <strong>awake</strong>, with a spinal injection that numbs you from the waist down, so you can meet your baby right away. A tube (catheter) drains your bladder and stays in for a while.</p>
+        </div>
+        <div class="card">
+          <div class="card-title"><i class="fas fa-heart-circle-check"></i> Why it may be chosen</div>
+          <p>Sometimes planned, sometimes decided in labour — for reasons like a breech baby, a low-lying placenta, the baby not coming down, or signs the baby should be born quickly. It is a decision made for <strong>safety, never a failure</strong> on your part.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">2</div><h2>Recovering well: the must-knows</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>It is major surgery. Full healing takes about <b>6 weeks</b> — be patient with yourself.</li>
+          <li>Start <b>gentle movement early</b> — it helps prevent clots and speeds healing.</li>
+          <li>Support your stitches with a hand or pillow when you cough, laugh or get up.</li>
+          <li>Take pain relief as prescribed — you do not need to suffer.</li>
+          <li>Avoid heavy lifting — <b>nothing heavier than your baby</b> at first.</li>
+          <li>Feed in positions that keep the baby's weight off your wound.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="warning-box">
+      <div class="warning-title"><i class="fas fa-hospital"></i> When to call your doctor</div>
+      <p style="font-size:.9rem;margin-bottom:8px;color:var(--text-light)">After a caesarean, get help if you notice:</p>
       <ul>
         <li>Fever or chills</li>
         <li>Redness, pus, swelling or a gap in the wound</li>
@@ -171,46 +82,45 @@
         <li>Breathlessness or chest pain</li>
       </ul>
     </div>
-  </div>
 
-  <!-- EMOTIONAL -->
-  <div class="sec">
-    <div class="soft">
-      <div class="st">It is still your birth</div>
+    <div class="reassure">
+      <div class="r-title"><i class="fas fa-heart"></i> It is still your birth</div>
       <p>A caesarean is a real birth, and a brave one. If you feel any sadness that it did not go as planned, that feeling is valid and it passes. Your bond with your baby and your feeding are exactly the same.</p>
     </div>
-  </div>
 
-  <!-- BLOGS -->
-  <div class="sec">
-    <div class="sec-title">Read more in the app</div>
-    <div class="blogs">
-      <div class="blogs-h">Helpful guides in the MiGynae App:</div>
-      <span class="blog-chip">Post-Delivery Recovery</span>
-      <span class="blog-chip">Caesarean Wound Care</span>
-      <span class="blog-chip">Breastfeeding Basics</span>
-      <span class="blog-chip">Eat to Recover (Postpartum Diet)</span>
-      <span class="blog-chip">Postpartum Exercises</span>
+    <div class="section">
+      <div class="section-header"><div class="section-number">3</div><h2>Read more in the app</h2></div>
+      <div class="section-body">
+        <p>Helpful guides inside MiGynae:</p>
+        <div class="chips">
+          <span class="chip">Post-Delivery Recovery</span>
+          <span class="chip">Caesarean Wound Care</span>
+          <span class="chip">Breastfeeding Basics</span>
+          <span class="chip">Eat to Recover (Postpartum Diet)</span>
+          <span class="chip">Postpartum Exercises</span>
+        </div>
+      </div>
     </div>
-  </div>
 
-  <!-- BOTTOM APP CTA -->
-  <div class="cta bottom">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Recover with confidence on the MiGynae App</h3>
-    <p>Wound care, feeding, recovery exercises and warning signs, step by step.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+    <div class="cta-section">
+      <h3>Recover with confidence — with the app</h3>
+      <p>Wound care, feeding, recovery exercises and warning signs, step by step.</p>
+      <div class="cta-buttons">
+        <a class="cta-btn cta-btn-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Get it on Play Store</a>
+        <a class="cta-btn cta-btn-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
+      </div>
     </div>
+
+    <div class="disclaimer">
+      General education only. Every caesarean and recovery is different. Always follow your obstetrician's advice, especially after any complications, pain, fever or heavy bleeding.
+    </div>
+
+    <div class="page-footer">
+      <a href="guides.html">&larr; All guides</a> &nbsp;&middot;&nbsp; <a href="index.html">MiGynae home</a><br>
+      &copy; 2026 MiGynae
+    </div>
+
   </div>
 
-  <!-- DISCLAIMER -->
-  <div class="disc">
-    General education only. Every caesarean and recovery is different. Always follow your obstetrician's advice, especially after any complications, pain, fever or heavy bleeding.
-  </div>
-  <div class="foot"><a href="index.html" style="color:inherit;text-decoration:none;border-bottom:1px solid currentColor;padding-bottom:1px;">← Back to MiGynae</a> &nbsp;·&nbsp; © 2026 MiGynae</div>
-
-</div>
 </body>
 </html>

--- a/css/guide-page.css
+++ b/css/guide-page.css
@@ -1,0 +1,135 @@
+/* MiGynae guide pages — shared design system (matches Labour Prep / Postpartum guides) */
+:root{
+  --primary:#D5B6DA; --primary-dark:#b98ec0; --primary-light:#f7f0f8;
+  --text-dark:#2c3e50; --text-light:#6c757d; --white:#ffffff;
+  --green:#27ae60; --green-dark:#1e8b4d; --green-light:#eafaf0;
+  --red:#e74c3c; --red-light:#fdecea; --amber:#f39c12; --amber-light:#fff8e6;
+}
+*{margin:0;padding:0;box-sizing:border-box;}
+body{font-family:'Segoe UI',-apple-system,BlinkMacSystemFont,Roboto,sans-serif;background:#fafafa;color:var(--text-dark);line-height:1.7;}
+
+/* ---- Hero ---- */
+.hero{background:linear-gradient(135deg,var(--primary) 0%,var(--primary-dark) 100%);color:#fff;padding:56px 24px 52px;text-align:center;position:relative;overflow:hidden;}
+.hero::before{content:'';position:absolute;top:-40px;right:-40px;width:200px;height:200px;background:rgba(255,255,255,.10);border-radius:50%;}
+.hero::after{content:'';position:absolute;bottom:-60px;left:-40px;width:240px;height:240px;background:rgba(255,255,255,.07);border-radius:50%;}
+.hero-inner{position:relative;z-index:1;max-width:680px;margin:0 auto;}
+.hero-brand{font-size:12px;font-weight:700;letter-spacing:2px;text-transform:uppercase;opacity:.9;margin-bottom:14px;}
+.hero h1{font-size:2.1rem;font-weight:800;line-height:1.2;margin-bottom:16px;}
+.hero-tagline{font-size:1.02rem;opacity:.96;max-width:540px;margin:0 auto;background:rgba(255,255,255,.15);border-radius:14px;padding:14px 20px;font-weight:500;}
+
+/* ---- Download bar (top, subtle) ---- */
+.download-bar{background:var(--primary);padding:16px 24px;display:flex;flex-wrap:wrap;gap:12px;justify-content:center;}
+.download-bar a{display:flex;align-items:center;justify-content:center;gap:10px;padding:12px 22px;border-radius:12px;text-decoration:none;font-weight:700;font-size:.9rem;transition:transform .2s ease;}
+.download-bar a:active{transform:scale(.97);}
+.dl-android{background:#1a1a1a;color:#fff;}
+.dl-ios{background:#fff;color:var(--primary-dark);}
+
+/* ---- Content column ---- */
+.content{max-width:680px;margin:0 auto;padding:0 16px 48px;}
+.intro-card{background:#fff;border-radius:16px;padding:22px 24px;margin:28px 0;border-left:4px solid var(--primary);box-shadow:0 2px 12px rgba(0,0,0,.06);font-size:1.02rem;}
+.intro-card strong,.highlight{color:var(--primary-dark);font-weight:600;}
+
+/* ---- Section blocks ---- */
+.section{margin:26px 0;}
+.section-header{background:linear-gradient(135deg,var(--primary) 0%,var(--primary-dark) 100%);color:#fff;border-radius:16px 16px 0 0;padding:16px 22px;display:flex;align-items:center;gap:12px;}
+.section-number{background:rgba(255,255,255,.25);width:34px;height:34px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:15px;flex-shrink:0;}
+.section-header h2{font-size:1.12rem;font-weight:700;line-height:1.3;}
+.section-body{background:#fff;border-radius:0 0 16px 16px;padding:22px;box-shadow:0 4px 16px rgba(0,0,0,.06);}
+.section-body>p{margin-bottom:10px;}
+.section-body>p:last-child{margin-bottom:0;}
+h3{font-size:1rem;font-weight:700;color:var(--text-dark);margin:16px 0 8px;}
+
+/* ---- Cards ---- */
+.card{background:var(--primary-light);border-radius:12px;padding:15px 18px;margin:14px 0;}
+.card:first-child{margin-top:0;}
+.card-title{font-weight:700;font-size:.88rem;color:var(--primary-dark);text-transform:uppercase;letter-spacing:.5px;margin-bottom:9px;display:flex;align-items:center;gap:8px;}
+.card p{font-size:.95rem;}
+.card.ok{background:var(--green-light);} .card.ok .card-title{color:var(--green-dark);}
+.card.no{background:var(--red-light);} .card.no .card-title{color:var(--red);}
+.card.warn-soft{background:var(--amber-light);} .card.warn-soft .card-title{color:#b9770a;}
+
+/* ---- Lists ---- */
+ul.check-list,ul.cross-list,ul.dot-list{list-style:none;padding:0;}
+ul.check-list li,ul.cross-list li{padding:5px 0 5px 26px;position:relative;font-size:.95rem;}
+ul.check-list li::before{content:'\2713';position:absolute;left:0;color:var(--green);font-weight:700;}
+ul.cross-list li::before{content:'\2715';position:absolute;left:0;color:var(--red);font-weight:700;}
+ul.dot-list li{padding:6px 0 6px 20px;position:relative;font-size:.95rem;}
+ul.dot-list li::before{content:'';position:absolute;left:2px;top:14px;width:7px;height:7px;border-radius:50%;background:var(--primary-dark);}
+ul.dot-list li b{color:var(--primary-dark);}
+
+/* ---- Two-column do / avoid ---- */
+.two-col{display:flex;gap:14px;flex-wrap:wrap;}
+.two-col>.card{flex:1;min-width:210px;}
+
+/* ---- Numbered tips ---- */
+.tip{display:flex;gap:14px;align-items:flex-start;padding:14px 0;border-top:1px solid #f1f1f1;}
+.tip:first-of-type{border-top:none;padding-top:2px;}
+.tip .n{flex:none;width:30px;height:30px;border-radius:50%;background:linear-gradient(135deg,var(--primary),var(--primary-dark));color:#fff;font-weight:800;font-size:14px;display:flex;align-items:center;justify-content:center;}
+.tip .tip-body strong{display:block;font-size:.98rem;color:var(--text-dark);margin-bottom:3px;}
+.tip .tip-body span{font-size:.93rem;color:var(--text-light);}
+.tip .tip-body span b{color:var(--primary-dark);}
+
+/* ---- Ask-doctor numbered questions ---- */
+ol.q-list{list-style:none;counter-reset:q;padding:0;}
+ol.q-list li{position:relative;padding:9px 0 9px 36px;font-size:.95rem;border-top:1px solid #f1f1f1;}
+ol.q-list li:first-child{border-top:none;}
+ol.q-list li::before{counter-increment:q;content:counter(q);position:absolute;left:0;top:8px;width:24px;height:24px;border-radius:50%;background:var(--primary-light);color:var(--primary-dark);font-weight:700;font-size:12px;display:flex;align-items:center;justify-content:center;}
+
+/* ---- Myths vs facts ---- */
+.mf-item{padding:12px 0;border-top:1px solid #f1f1f1;}
+.mf-item:first-child{border-top:none;}
+.mf-line{font-size:.94rem;line-height:1.55;}
+.mf-line+.mf-line{margin-top:5px;}
+.mf-tag{display:inline-block;font-size:10px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;padding:2px 8px;border-radius:12px;margin-right:7px;vertical-align:middle;}
+.mf-tag.myth{background:var(--red-light);color:var(--red);}
+.mf-tag.fact{background:var(--green-light);color:var(--green-dark);}
+
+/* ---- Warning box ---- */
+.warning-box{background:var(--amber-light);border-left:4px solid var(--amber);border-radius:0 12px 12px 0;padding:16px 18px;margin:16px 0;}
+.warning-box .warning-title{font-weight:700;color:#b9770a;margin-bottom:8px;display:flex;align-items:center;gap:8px;font-size:1rem;}
+.warning-box ul{list-style:none;padding:0;}
+.warning-box li{padding:5px 0 5px 20px;position:relative;font-size:.94rem;}
+.warning-box li::before{content:'\2022';position:absolute;left:4px;color:var(--amber);font-weight:700;}
+
+/* ---- Reassure / good-to-know ---- */
+.reassure{background:var(--green-light);border-radius:14px;padding:16px 18px;margin:16px 0;}
+.reassure .r-title{font-weight:700;color:var(--green-dark);margin-bottom:6px;}
+.reassure p{font-size:.94rem;}
+.note-quote{background:linear-gradient(135deg,var(--primary-light),#fff);border-left:4px solid var(--primary);border-radius:12px;padding:16px 20px;margin:22px 0;font-style:italic;font-size:1rem;}
+.note-quote .foot-line{display:block;font-style:normal;font-size:.85rem;color:var(--text-light);margin-top:8px;}
+
+/* ---- Chips ---- */
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:6px;}
+.chip{background:var(--primary-light);color:var(--primary-dark);font-size:.86rem;font-weight:600;padding:7px 14px;border-radius:20px;}
+
+/* ---- Timeline ---- */
+.timeline{position:relative;margin:6px 0 6px 6px;}
+.timeline::before{content:'';position:absolute;left:5px;top:6px;bottom:10px;width:2px;background:var(--primary-light);}
+.tl-node{position:relative;padding:0 0 16px 26px;}
+.tl-node:last-child{padding-bottom:0;}
+.tl-node::before{content:'';position:absolute;left:0;top:4px;width:12px;height:12px;border-radius:50%;background:var(--primary-dark);border:2px solid #fff;box-shadow:0 0 0 2px var(--primary-light);}
+.tl-1{font-weight:700;font-size:.95rem;color:var(--primary-dark);}
+.tl-2{font-size:.9rem;color:var(--text-light);}
+
+/* ---- CTA at end ---- */
+.cta-section{background:linear-gradient(135deg,var(--primary) 0%,var(--primary-dark) 100%);border-radius:20px;padding:34px 24px;text-align:center;color:#fff;margin:30px 0 8px;}
+.cta-section h3{font-size:1.35rem;font-weight:800;margin-bottom:8px;color:#fff;}
+.cta-section p{font-size:.95rem;opacity:.92;margin-bottom:22px;}
+.cta-buttons{display:flex;flex-direction:column;gap:12px;max-width:300px;margin:0 auto;}
+.cta-btn{display:flex;align-items:center;justify-content:center;gap:10px;padding:14px 24px;border-radius:12px;text-decoration:none;font-weight:700;font-size:.95rem;transition:transform .2s ease;}
+.cta-btn:active{transform:scale(.97);}
+.cta-btn-android{background:#1a1a1a;color:#fff;}
+.cta-btn-ios{background:#fff;color:var(--primary-dark);}
+
+/* ---- Disclaimer + footer ---- */
+.disclaimer{background:#fff;border:1px solid #eee;border-radius:12px;padding:14px 18px;margin:18px 0;font-size:.82rem;color:var(--text-light);text-align:center;}
+.page-footer{text-align:center;padding:8px 16px 44px;font-size:.85rem;color:var(--text-light);}
+.page-footer a{color:var(--primary-dark);text-decoration:none;font-weight:600;}
+.page-footer a:hover{text-decoration:underline;}
+
+/* ---- Desktop ---- */
+@media(min-width:768px){
+  .hero{padding:72px 24px 64px;}
+  .hero h1{font-size:2.6rem;}
+  .content{padding-bottom:64px;}
+}

--- a/during-labour-guide.html
+++ b/during-labour-guide.html
@@ -3,205 +3,103 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>During Labour - Quick Guide | MiGynae App</title>
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
-    <meta name="description" content="What to know when labour begins: slow breathing, movement and positions, when not to push, resting between contractions, and asking for pain relief.">
-    <link rel="canonical" href="https://migynaeapp.com/during-labour-guide.html">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://migynaeapp.com/during-labour-guide.html">
-    <meta property="og:title" content="During Labour - Quick Guide | MiGynae App">
-    <meta property="og:description" content="What to know when labour begins: slow breathing, movement and positions, when not to push, resting between contractions, and asking for pain relief.">
-    <meta property="og:image" content="https://migynaeapp.com/images/logo.webp">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="During Labour - Quick Guide | MiGynae App">
-    <meta name="twitter:description" content="What to know when labour begins: slow breathing, movement and positions, when not to push, resting between contractions, and asking for pain relief.">
-<style>
-  :root{
-    --green:#2f4a3d; --green-soft:#3f5e4f; --cream:#faf6ee; --card:#ffffff;
-    --ink:#2c2622; --muted:#6b655d; --line:#e7ded0; --gold:#c8974a;
-    --rose:#b6524c; --rose-bg:#fbeeed; --ok:#3f7a5a; --ok-bg:#eef5f0;
-    --serif:Georgia,'Times New Roman',serif;      /* -> Lora */
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; /* -> DM Sans */
-  }
-  *{box-sizing:border-box;margin:0;padding:0;}
-  body{background:#d9d3c7;font-family:var(--sans);color:var(--ink);display:flex;justify-content:center;padding:24px 12px;-webkit-font-smoothing:antialiased;}
-  .phone{width:390px;max-width:100%;background:var(--cream);border-radius:28px;overflow:hidden;box-shadow:0 12px 40px rgba(0,0,0,.18);}
-
-  .cta{background:var(--green);color:#fff;padding:18px 20px 20px;}
-  .cta.bottom{padding:22px 20px 26px;}
-  .cta h3{font-family:var(--serif);font-weight:600;font-size:16px;line-height:1.35;margin:6px 0 4px;}
-  .cta p{font-size:12.5px;color:#d9e5df;line-height:1.5;margin-bottom:14px;}
-  .stores{display:flex;gap:8px;}
-  .store{flex:1;display:flex;align-items:center;gap:8px;background:#fff;color:var(--green);text-decoration:none;padding:9px 10px;border-radius:11px;font-size:11px;font-weight:600;line-height:1.2;}
-  .store .ico{font-size:16px;line-height:1;}
-  .store small{display:block;font-size:8.5px;font-weight:500;color:var(--muted);letter-spacing:.3px;}
-
-  .logo-badge{width:40px;height:40px;border-radius:50%;background:#fff;padding:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,.12);}
-  .logo-badge img{width:100%;height:100%;object-fit:contain;border-radius:50%;}
-  .head .logo-badge{width:64px;height:64px;margin:0 auto 14px;}
-
-  .head{padding:22px 22px 6px;text-align:center;}
-  .kicker{font-size:10.5px;letter-spacing:1.6px;text-transform:uppercase;color:var(--gold);font-weight:700;margin-bottom:8px;}
-  .head h1{font-family:var(--serif);font-weight:600;font-size:23px;line-height:1.25;color:var(--green);}
-  .head .sub{font-size:13px;color:var(--muted);line-height:1.55;margin-top:10px;}
-
-  .sec{padding:20px 22px 4px;}
-  .sec-title{font-family:var(--serif);font-size:17px;font-weight:600;color:var(--green);margin-bottom:12px;}
-
-  .tip{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;margin-bottom:10px;display:flex;gap:12px;}
-  .tip .n{flex:none;width:26px;height:26px;border-radius:50%;background:var(--green);color:#fff;font-size:13px;font-weight:700;display:flex;align-items:center;justify-content:center;}
-  .tip .t1{font-size:14px;font-weight:700;color:var(--green);margin-bottom:3px;}
-  .tip .t2{font-size:12.5px;line-height:1.5;color:var(--ink);}
-  .tip .t2 b{color:var(--green);}
-
-  .more{margin:18px 22px 4px;background:var(--green);border-radius:15px;padding:18px 18px 16px;color:#fff;}
-  .more h3{font-family:var(--serif);font-size:16px;font-weight:600;margin-bottom:4px;}
-  .more .msub{font-size:12px;color:#cfe0d8;margin-bottom:12px;}
-  .more ul{list-style:none;}
-  .more li{font-size:13px;line-height:1.4;padding:8px 0 8px 22px;position:relative;border-top:1px solid rgba(255,255,255,.12);}
-  .more li:first-child{border-top:none;}
-  .more li::before{content:"→";position:absolute;left:4px;color:var(--gold);font-weight:700;}
-
-  .blogs{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;}
-  .blogs-h{font-size:12px;color:var(--muted);line-height:1.45;margin-bottom:10px;}
-  .blog-chip{display:inline-block;background:var(--ok-bg);color:var(--green);font-size:12px;font-weight:600;padding:7px 12px;border-radius:20px;margin:0 6px 6px 0;border:1px solid #d9e7de;}
-  .chip-add{display:inline-block;background:transparent;color:var(--muted);font-size:12px;font-weight:600;padding:7px 12px;border-radius:20px;margin:0 6px 6px 0;border:1px dashed #cbb98f;}
-
-  .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
-  .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
-  /* ===== Desktop / web view: full-width page with a centered content column ===== */
-  @media (min-width: 768px){
-    body{ padding:0; }
-    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
-
-    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
-    .phone > *{
-      padding-left: max(24px, calc((100% - 760px) / 2));
-      padding-right: max(24px, calc((100% - 760px) / 2));
-    }
-    /* inset coloured cards become full-bleed bands too */
-    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
-    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
-    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
-
-    /* larger, web-friendly typography */
-    .head{ padding-top:52px; }
-    .head .logo-badge{ width:80px; height:80px; }
-    .head h1{ font-size:34px; line-height:1.2; }
-    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
-    .cta h3{ font-size:20px; }
-    .cta p{ font-size:14px; }
-    /* store buttons: natural badge size instead of stretching full width */
-    .stores{ gap:12px; justify-content:flex-start; }
-    .store{ flex:0 0 auto; width:210px; }
-    .sec-title{ font-size:22px; }
-    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
-    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
-    .disc{ font-size:12px; }
-  }
-
-</style>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<title>During Labour Guide | MiGynae</title>
+<meta name="description" content="What to know when labour begins: slow breathing, movement and positions, when not to push, resting between contractions, and asking for pain relief.">
+<link rel="canonical" href="https://migynaeapp.com/during-labour-guide.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://migynaeapp.com/during-labour-guide.html">
+<meta property="og:title" content="During Labour Guide | MiGynae">
+<meta property="og:description" content="What to know when labour begins: slow breathing, movement and positions, when not to push, resting between contractions, and asking for pain relief.">
+<meta property="og:image" content="https://migynaeapp.com/images/blog/labour-guide-banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="During Labour Guide | MiGynae">
+<meta name="twitter:description" content="What to know when labour begins: slow breathing, movement and positions, when not to push, resting between contractions, and asking for pain relief.">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="css/guide-page.css">
 </head>
 <body>
-<div class="phone">
 
-  <!-- TOP APP CTA -->
-  <div class="cta">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Stay calm and in control through labour - with the MiGynae App</h3>
-    <p>Contraction timer, kick counter and doctor-backed guidance when you need it most.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+  <div class="hero">
+    <div class="hero-inner">
+      <div class="hero-brand">During Labour</div>
+      <h1>What to know when labour begins</h1>
+      <p class="hero-tagline">When the contractions are here, keep it simple. A few things make the biggest difference in the moment — save these.</p>
     </div>
   </div>
 
-  <!-- HEADER -->
-  <div class="head">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <div class="kicker">During Labour</div>
-    <h1>What to know when labour begins</h1>
-    <p class="sub">When the contractions are here, keep it simple. A few things make the biggest difference in the moment - save these.</p>
+  <div class="download-bar">
+    <a class="dl-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Download on Play Store</a>
+    <a class="dl-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
   </div>
 
-  <!-- MOST IMPORTANT TIPS -->
-  <div class="sec">
-    <div class="sec-title">The tips that matter most</div>
+  <div class="content">
 
-    <div class="tip">
-      <div class="n">1</div>
-      <div class="b">
-        <div class="t1">Breathe slow, don't panic</div>
-        <div class="t2">Take a slow, deep breath in and let it out slowly. <b>Panic-breathing makes pain feel worse</b> - steady breathing calms your body and lowers the pain. This is your single biggest tool.</div>
+    <div class="intro-card">
+      You do not need to remember much. These five things calm your body, ease the pain, and help your baby move down.
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">1</div><h2>The tips that matter most</h2></div>
+      <div class="section-body">
+        <div class="tip">
+          <div class="n">1</div>
+          <div class="tip-body"><strong>Breathe slow, don't panic</strong><span>Take a slow, deep breath in and let it out slowly. <b>Panic-breathing makes pain feel worse</b> — steady breathing calms your body and lowers the pain. This is your single biggest tool.</span></div>
+        </div>
+        <div class="tip">
+          <div class="n">2</div>
+          <div class="tip-body"><strong>Keep moving, change position</strong><span>Walk, sway, or rock on a birthing ball. Upright positions — <b>squatting, leaning forward, lying on your side</b> — help your baby move down.</span></div>
+        </div>
+        <div class="tip">
+          <div class="n">3</div>
+          <div class="tip-body"><strong>Do NOT push early</strong><span>Even if you feel the urge, <b>push only when your doctor tells you to</b>. Pushing too soon tires you out and can cause tearing.</span></div>
+        </div>
+        <div class="tip">
+          <div class="n">4</div>
+          <div class="tip-body"><strong>Rest and sip between contractions</strong><span>Use the gaps to relax your shoulders and jaw, breathe, and sip water. <b>Saving energy now helps you push better later.</b></span></div>
+        </div>
+        <div class="tip">
+          <div class="n">5</div>
+          <div class="tip-body"><strong>It's okay to ask for pain relief</strong><span>If pain feels unbearable or labour is long, you can ask about an <b>epidural</b>. Used correctly, it is a safe option — there is no prize for suffering.</span></div>
+        </div>
       </div>
     </div>
 
-    <div class="tip">
-      <div class="n">2</div>
-      <div class="b">
-        <div class="t1">Keep moving, change position</div>
-        <div class="t2">Walk, sway, or rock on a birthing ball. Upright positions - <b>squatting, leaning forward, lying on your side</b> - help your baby move down.</div>
+    <div class="section">
+      <div class="section-header"><div class="section-number">2</div><h2>More inside the full app guide</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>The <b>stages of labour</b>, start to finish</li>
+          <li>Contraction timer and <b>when to leave for the hospital</b></li>
+          <li>How to deal with labour pains, step by step</li>
+          <li>Understanding the epidural</li>
+          <li>How your birth partner can help</li>
+        </ul>
       </div>
     </div>
 
-    <div class="tip">
-      <div class="n">3</div>
-      <div class="b">
-        <div class="t1">Do NOT push early</div>
-        <div class="t2">Even if you feel the urge, <b>push only when your doctor tells you to</b>. Pushing too soon tires you out and can cause tearing.</div>
+    <div class="cta-section">
+      <h3>Stay calm and in control — with the app</h3>
+      <p>Contraction timer, kick counter and doctor-backed guidance for every stage of labour.</p>
+      <div class="cta-buttons">
+        <a class="cta-btn cta-btn-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Get it on Play Store</a>
+        <a class="cta-btn cta-btn-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
       </div>
     </div>
 
-    <div class="tip">
-      <div class="n">4</div>
-      <div class="b">
-        <div class="t1">Rest and sip between contractions</div>
-        <div class="t2">Use the gaps to relax your shoulders and jaw, breathe, and sip water. <b>Saving energy now helps you push better later.</b></div>
-      </div>
+    <div class="disclaimer">
+      General guidance for a low-risk labour. Always follow your obstetrician and birth team, especially if you have any complications or your doctor has advised a planned caesarean.
     </div>
 
-    <div class="tip">
-      <div class="n">5</div>
-      <div class="b">
-        <div class="t1">It's okay to ask for pain relief</div>
-        <div class="t2">If pain feels unbearable or labour is long, you can ask about an <b>epidural</b>. Used correctly, it is a safe option - there is no prize for suffering.</div>
-      </div>
+    <div class="page-footer">
+      <a href="guides.html">&larr; All guides</a> &nbsp;&middot;&nbsp; <a href="index.html">MiGynae home</a><br>
+      &copy; 2026 MiGynae
     </div>
+
   </div>
 
-  <!-- MORE IN APP -->
-  <div class="more">
-    <h3>The full guide is in the app</h3>
-    <div class="msub">Everything above, plus the parts too detailed to fit here:</div>
-    <ul>
-      <li>The stages of labour, start to finish</li>
-      <li>Contraction timer and when to leave for the hospital</li>
-      <li>How to deal with labour pains, step by step</li>
-      <li>Understanding the epidural</li>
-      <li>How your birth partner can help</li>
-    </ul>
-  </div>
-
-  <!-- BOTTOM APP CTA -->
-  <div class="cta bottom">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Get calm, step-by-step labour support on the MiGynae App</h3>
-    <p>Contraction timer, kick counter and guidance for every stage.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
-    </div>
-  </div>
-
-  <!-- DISCLAIMER -->
-  <div class="disc">
-    General guidance for a low-risk labour. Always follow your obstetrician and birth team, especially if you have any complications or your doctor has advised a planned caesarean.
-  </div>
-  <div class="foot"><a href="index.html" style="color:inherit;text-decoration:none;border-bottom:1px solid currentColor;padding-bottom:1px;">← Back to MiGynae</a> &nbsp;·&nbsp; © 2026 MiGynae</div>
-
-</div>
 </body>
 </html>

--- a/epidural-guide.html
+++ b/epidural-guide.html
@@ -3,256 +3,122 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>The Epidural, Explained - Quick Guide | MiGynae App</title>
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
-    <meta name="description" content="The epidural explained: what it is, what to expect, myths vs facts, and the right questions to ask your doctor or anaesthetist.">
-    <link rel="canonical" href="https://migynaeapp.com/epidural-guide.html">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://migynaeapp.com/epidural-guide.html">
-    <meta property="og:title" content="The Epidural, Explained - Quick Guide | MiGynae App">
-    <meta property="og:description" content="The epidural explained: what it is, what to expect, myths vs facts, and the right questions to ask your doctor or anaesthetist.">
-    <meta property="og:image" content="https://migynaeapp.com/images/logo.webp">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="The Epidural, Explained - Quick Guide | MiGynae App">
-    <meta name="twitter:description" content="The epidural explained: what it is, what to expect, myths vs facts, and the right questions to ask your doctor or anaesthetist.">
-<style>
-  :root{
-    --green:#2f4a3d; --cream:#faf6ee; --card:#ffffff;
-    --ink:#2c2622; --muted:#6b655d; --line:#e7ded0; --gold:#c8974a;
-    --rose:#b6524c; --rose-bg:#fbeeed; --ok:#3f7a5a; --ok-bg:#eef5f0;
-    --serif:Georgia,'Times New Roman',serif;      /* -> Lora */
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; /* -> DM Sans */
-  }
-  *{box-sizing:border-box;margin:0;padding:0;}
-  body{background:#d9d3c7;font-family:var(--sans);color:var(--ink);display:flex;justify-content:center;padding:24px 12px;-webkit-font-smoothing:antialiased;}
-  .phone{width:390px;max-width:100%;background:var(--cream);border-radius:28px;overflow:hidden;box-shadow:0 12px 40px rgba(0,0,0,.18);}
-
-  .cta{background:var(--green);color:#fff;padding:18px 20px 20px;}
-  .cta.bottom{padding:22px 20px 26px;}
-  .cta h3{font-family:var(--serif);font-weight:600;font-size:16px;line-height:1.35;margin:6px 0 4px;}
-  .cta p{font-size:12.5px;color:#d9e5df;line-height:1.5;margin-bottom:14px;}
-  .stores{display:flex;gap:8px;}
-  .store{flex:1;display:flex;align-items:center;gap:8px;background:#fff;color:var(--green);text-decoration:none;padding:9px 10px;border-radius:11px;font-size:11px;font-weight:600;line-height:1.2;}
-  .store .ico{font-size:16px;line-height:1;}
-  .store small{display:block;font-size:8.5px;font-weight:500;color:var(--muted);letter-spacing:.3px;}
-
-  .logo-badge{width:40px;height:40px;border-radius:50%;background:#fff;padding:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,.12);}
-  .logo-badge img{width:100%;height:100%;object-fit:contain;border-radius:50%;}
-  .head .logo-badge{width:64px;height:64px;margin:0 auto 14px;}
-
-  .head{padding:22px 22px 6px;text-align:center;}
-  .kicker{font-size:10.5px;letter-spacing:1.6px;text-transform:uppercase;color:var(--gold);font-weight:700;margin-bottom:8px;}
-  .head h1{font-family:var(--serif);font-weight:600;font-size:23px;line-height:1.25;color:var(--green);}
-  .head .sub{font-size:13px;color:var(--muted);line-height:1.55;margin-top:10px;}
-
-  .sec{padding:20px 22px 4px;}
-  .sec-title{font-family:var(--serif);font-size:17px;font-weight:600;color:var(--green);margin-bottom:12px;}
-
-  .row{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;margin-bottom:10px;}
-  .row p{font-size:13px;line-height:1.55;color:var(--ink);}
-  .row p b{color:var(--green);}
-
-  .tip{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;margin-bottom:10px;display:flex;gap:12px;}
-  .tip .n{flex:none;width:26px;height:26px;border-radius:50%;background:var(--green);color:#fff;font-size:13px;font-weight:700;display:flex;align-items:center;justify-content:center;}
-  .tip .t1{font-size:13.5px;font-weight:700;color:var(--green);margin-bottom:2px;}
-  .tip .t2{font-size:12.5px;line-height:1.5;color:var(--ink);}
-
-  .mf{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:4px 14px;}
-  .mf-item{padding:12px 0;border-top:1px solid var(--line);}
-  .mf-item:first-child{border-top:none;}
-  .mf-line{font-size:12.5px;line-height:1.5;color:var(--ink);}
-  .mf-line + .mf-line{margin-top:5px;}
-  .mf-k{display:inline-block;font-size:9.5px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;padding:2px 7px;border-radius:12px;margin-right:6px;}
-  .mf-k.no{background:var(--rose-bg);color:var(--rose);}
-  .mf-k.ok{background:var(--ok-bg);color:var(--ok);}
-
-  .callout{background:#fbf6ec;border:1px solid #efe0c4;border-radius:13px;padding:13px 15px;}
-  .callout .ct{font-size:11.5px;font-weight:700;letter-spacing:.4px;text-transform:uppercase;color:#a9781f;margin-bottom:6px;}
-  .callout p{font-size:12.5px;line-height:1.6;color:var(--ink);}
-
-  .ask{background:var(--green);border-radius:15px;padding:16px 18px 14px;color:#fff;}
-  .ask h3{font-family:var(--serif);font-size:16px;font-weight:600;margin-bottom:4px;}
-  .ask .asub{font-size:11.5px;color:#cfe0d8;margin-bottom:12px;}
-  .ask ol{list-style:none;counter-reset:q;}
-  .ask li{font-size:13px;line-height:1.45;padding:9px 0 9px 30px;position:relative;border-top:1px solid rgba(255,255,255,.12);}
-  .ask li:first-child{border-top:none;}
-  .ask li::before{counter-increment:q;content:counter(q);position:absolute;left:2px;top:9px;width:18px;height:18px;border-radius:50%;background:var(--gold);color:var(--green);font-size:11px;font-weight:700;text-align:center;line-height:18px;}
-
-  .more{margin:18px 22px 4px;background:var(--green);border-radius:15px;padding:18px 18px 16px;color:#fff;}
-  .more h3{font-family:var(--serif);font-size:16px;font-weight:600;margin-bottom:4px;}
-  .more .msub{font-size:12px;color:#cfe0d8;margin-bottom:12px;}
-  .more ul{list-style:none;}
-  .more li{font-size:13px;line-height:1.4;padding:8px 0 8px 22px;position:relative;border-top:1px solid rgba(255,255,255,.12);}
-  .more li:first-child{border-top:none;}
-  .more li::before{content:"→";position:absolute;left:4px;color:var(--gold);font-weight:700;}
-
-  .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
-  .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
-  /* ===== Desktop / web view: full-width page with a centered content column ===== */
-  @media (min-width: 768px){
-    body{ padding:0; }
-    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
-
-    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
-    .phone > *{
-      padding-left: max(24px, calc((100% - 760px) / 2));
-      padding-right: max(24px, calc((100% - 760px) / 2));
-    }
-    /* inset coloured cards become full-bleed bands too */
-    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
-    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
-    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
-
-    /* larger, web-friendly typography */
-    .head{ padding-top:52px; }
-    .head .logo-badge{ width:80px; height:80px; }
-    .head h1{ font-size:34px; line-height:1.2; }
-    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
-    .cta h3{ font-size:20px; }
-    .cta p{ font-size:14px; }
-    /* store buttons: natural badge size instead of stretching full width */
-    .stores{ gap:12px; justify-content:flex-start; }
-    .store{ flex:0 0 auto; width:210px; }
-    .sec-title{ font-size:22px; }
-    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
-    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
-    .disc{ font-size:12px; }
-  }
-
-</style>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<title>The Epidural, Explained | MiGynae</title>
+<meta name="description" content="The epidural explained: what it is, what to expect, myths vs facts, and the right questions to ask your doctor or anaesthetist.">
+<link rel="canonical" href="https://migynaeapp.com/epidural-guide.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://migynaeapp.com/epidural-guide.html">
+<meta property="og:title" content="The Epidural, Explained | MiGynae">
+<meta property="og:description" content="The epidural explained: what it is, what to expect, myths vs facts, and the right questions to ask your doctor or anaesthetist.">
+<meta property="og:image" content="https://migynaeapp.com/images/blog/labour-guide-banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The Epidural, Explained | MiGynae">
+<meta name="twitter:description" content="The epidural explained: what it is, what to expect, myths vs facts, and the right questions to ask your doctor or anaesthetist.">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="css/guide-page.css">
 </head>
 <body>
-<div class="phone">
 
-  <!-- TOP APP CTA -->
-  <div class="cta">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Everything else about your birth - inside the MiGynae App</h3>
-    <p>Diet, exercise, coping with labour pain, and doctor-backed guidance for every stage.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+  <div class="hero">
+    <div class="hero-inner">
+      <div class="hero-brand">Pain Relief in Labour</div>
+      <h1>The Epidural, explained</h1>
+      <p class="hero-tagline">The most effective pain relief in labour, and one of the most misunderstood. Here is what it actually is, so you can decide with confidence.</p>
     </div>
   </div>
 
-  <!-- HEADER -->
-  <div class="head">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <div class="kicker">Pain Relief in Labour</div>
-    <h1>The Epidural, explained</h1>
-    <p class="sub">The most effective pain relief in labour, and one of the most misunderstood. Here is what it actually is, so you can decide with confidence.</p>
+  <div class="download-bar">
+    <a class="dl-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Download on Play Store</a>
+    <a class="dl-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
   </div>
 
-  <!-- WHAT IT IS -->
-  <div class="sec">
-    <div class="sec-title">What an epidural is</div>
-    <div class="row">
-      <p>A pain-relief injection given in your <b>lower back</b> during labour. It numbs the lower half of your body, so contractions hurt far less, while you stay <b>fully awake and alert</b>. A thin, soft tube is left in place so the medicine can be topped up as your labour goes on.</p>
+  <div class="content">
+
+    <div class="intro-card">
+      An epidural can make labour far more comfortable while you stay awake and in control. Knowing how it works takes the fear out of the decision.
     </div>
-    <div class="row">
-      <p><b>When can you ask?</b> When labour pain becomes hard to manage. It is usually given once labour is well established, but the timing is decided with your doctor and anaesthetist based on how you are progressing. There is no prize for suffering, it is okay to ask.</p>
-    </div>
-  </div>
 
-  <!-- WHAT TO EXPECT -->
-  <div class="sec">
-    <div class="sec-title">What to expect</div>
-
-    <div class="tip"><div class="n">1</div><div class="b">
-      <div class="t1">Getting it placed</div>
-      <div class="t2">You will sit or lie curled forward and stay as still as you can for a few minutes.</div></div></div>
-
-    <div class="tip"><div class="n">2</div><div class="b">
-      <div class="t1">A gentle start</div>
-      <div class="t2">A small local injection numbs the skin first, so placing the tube feels like pressure, not sharp pain.</div></div></div>
-
-    <div class="tip"><div class="n">3</div><div class="b">
-      <div class="t1">Relief begins</div>
-      <div class="t2">The pain usually eases within about 10 to 20 minutes.</div></div></div>
-
-    <div class="tip"><div class="n">4</div><div class="b">
-      <div class="t1">You will be monitored</div>
-      <div class="t2">Your blood pressure and your baby's heartbeat are watched closely. You may need a small tube to empty your bladder.</div></div></div>
-
-    <div class="tip"><div class="n">5</div><div class="b">
-      <div class="t1">Heavy legs</div>
-      <div class="t2">Your legs will feel heavy or numb. That is normal and wears off after birth.</div></div></div>
-  </div>
-
-  <!-- MYTHS VS FACTS -->
-  <div class="sec">
-    <div class="sec-title">Myths vs facts</div>
-    <div class="mf">
-      <div class="mf-item">
-        <div class="mf-line"><span class="mf-k no">Myth</span>It causes lifelong back pain.</div>
-        <div class="mf-line"><span class="mf-k ok">Fact</span>Research does not support this. Some soreness at the spot for a day or two can happen.</div>
-      </div>
-      <div class="mf-item">
-        <div class="mf-line"><span class="mf-k no">Myth</span>It always leads to a C-section.</div>
-        <div class="mf-line"><span class="mf-k ok">Fact</span>It does not. It may make pushing a little longer, and sometimes a little help is needed to birth the baby.</div>
-      </div>
-      <div class="mf-item">
-        <div class="mf-line"><span class="mf-k no">Myth</span>You cannot push with an epidural.</div>
-        <div class="mf-line"><span class="mf-k ok">Fact</span>You can. Your team guides you on when to push, and many women still feel pressure.</div>
+    <div class="section">
+      <div class="section-header"><div class="section-number">1</div><h2>What an epidural is</h2></div>
+      <div class="section-body">
+        <p>A pain-relief injection given in your <span class="highlight">lower back</span> during labour. It numbs the lower half of your body, so contractions hurt far less, while you stay <strong>fully awake and alert</strong>. A thin, soft tube is left in place so the medicine can be topped up as your labour goes on.</p>
+        <div class="card">
+          <div class="card-title"><i class="fas fa-clock"></i> When can you ask?</div>
+          <p>When labour pain becomes hard to manage. It is usually given once labour is well established, but the timing is decided with your doctor and anaesthetist based on how you are progressing. There is no prize for suffering — it is okay to ask.</p>
+        </div>
       </div>
     </div>
-  </div>
 
-  <!-- GOOD TO KNOW -->
-  <div class="sec">
-    <div class="callout">
-      <div class="ct">Good to know</div>
-      <p>Most women do very well. Some feel shivering, itching, or a short drop in blood pressure that the team manages quickly. A bad headache afterwards is uncommon, and serious problems are rare. A few conditions, like certain bleeding problems, some spine issues, or blood-thinning medicines, can make an epidural unsuitable, so your anaesthetist will always check first.</p>
+    <div class="section">
+      <div class="section-header"><div class="section-number">2</div><h2>What to expect</h2></div>
+      <div class="section-body">
+        <div class="tip"><div class="n">1</div><div class="tip-body"><strong>Getting it placed</strong><span>You will sit or lie curled forward and stay as still as you can for a few minutes.</span></div></div>
+        <div class="tip"><div class="n">2</div><div class="tip-body"><strong>A gentle start</strong><span>A small local injection numbs the skin first, so placing the tube feels like pressure, not sharp pain.</span></div></div>
+        <div class="tip"><div class="n">3</div><div class="tip-body"><strong>Relief begins</strong><span>The pain usually eases within about 10 to 20 minutes.</span></div></div>
+        <div class="tip"><div class="n">4</div><div class="tip-body"><strong>You will be monitored</strong><span>Your blood pressure and your baby's heartbeat are watched closely. You may need a small tube to empty your bladder.</span></div></div>
+        <div class="tip"><div class="n">5</div><div class="tip-body"><strong>Heavy legs</strong><span>Your legs will feel heavy or numb. That is normal and wears off after birth.</span></div></div>
+      </div>
     </div>
-  </div>
 
-  <!-- ASK -->
-  <div class="sec">
-    <div class="ask">
-      <h3>Ask your doctor or anaesthetist</h3>
-      <div class="asub">A few good questions to feel ready:</div>
-      <ol>
-        <li>Am I a good candidate for an epidural?</li>
-        <li>When can I have it, and is it ever too late?</li>
-        <li>Will I still be able to move or push?</li>
-        <li>What side effects should I watch for?</li>
-      </ol>
+    <div class="section">
+      <div class="section-header"><div class="section-number">3</div><h2>Myths vs facts</h2></div>
+      <div class="section-body">
+        <div class="mf-item">
+          <div class="mf-line"><span class="mf-tag myth">Myth</span>It causes lifelong back pain.</div>
+          <div class="mf-line"><span class="mf-tag fact">Fact</span>Research does not support this. Some soreness at the spot for a day or two can happen.</div>
+        </div>
+        <div class="mf-item">
+          <div class="mf-line"><span class="mf-tag myth">Myth</span>It always leads to a C-section.</div>
+          <div class="mf-line"><span class="mf-tag fact">Fact</span>It does not. It may make pushing a little longer, and sometimes a little help is needed to birth the baby.</div>
+        </div>
+        <div class="mf-item">
+          <div class="mf-line"><span class="mf-tag myth">Myth</span>You cannot push with an epidural.</div>
+          <div class="mf-line"><span class="mf-tag fact">Fact</span>You can. Your team guides you on when to push, and many women still feel pressure.</div>
+        </div>
+      </div>
     </div>
-  </div>
 
-  <!-- MORE IN APP -->
-  <div class="more">
-    <h3>The rest of your birth prep is in the app</h3>
-    <div class="msub">Everything beyond pain relief:</div>
-    <ul>
-      <li>Exercise for a normal delivery, and 3rd trimester exercise</li>
-      <li>Foods for normal delivery, and 3rd trimester diet</li>
-      <li>How to deal with labour pains without medicine</li>
-      <li>What to know when labour begins</li>
-      <li>Contraction timer and kick counter</li>
-    </ul>
-  </div>
-
-  <!-- BOTTOM APP CTA -->
-  <div class="cta bottom">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Get doctor-backed birth and recovery guidance on the MiGynae App</h3>
-    <p>Diet, exercise, labour pain relief and more, all in one place.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+    <div class="reassure">
+      <div class="r-title"><i class="fas fa-circle-info"></i> Good to know</div>
+      <p>Most women do very well. Some feel shivering, itching, or a short drop in blood pressure that the team manages quickly. A bad headache afterwards is uncommon, and serious problems are rare. A few conditions — like certain bleeding problems, some spine issues, or blood-thinning medicines — can make an epidural unsuitable, so your anaesthetist will always check first.</p>
     </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">4</div><h2>Ask your doctor or anaesthetist</h2></div>
+      <div class="section-body">
+        <p>A few good questions to feel ready:</p>
+        <ol class="q-list">
+          <li>Am I a good candidate for an epidural?</li>
+          <li>When can I have it, and is it ever too late?</li>
+          <li>Will I still be able to move or push?</li>
+          <li>What side effects should I watch for?</li>
+        </ol>
+      </div>
+    </div>
+
+    <div class="cta-section">
+      <h3>The rest of your birth prep is in the app</h3>
+      <p>Exercise and diet for a normal delivery, coping with labour pain, and doctor-backed guidance for every stage.</p>
+      <div class="cta-buttons">
+        <a class="cta-btn cta-btn-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Get it on Play Store</a>
+        <a class="cta-btn cta-btn-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
+      </div>
+    </div>
+
+    <div class="disclaimer">
+      General education only. Whether an epidural is right and safe for you is decided by your doctor and anaesthetist. Always follow your own care team's advice.
+    </div>
+
+    <div class="page-footer">
+      <a href="guides.html">&larr; All guides</a> &nbsp;&middot;&nbsp; <a href="index.html">MiGynae home</a><br>
+      &copy; 2026 MiGynae
+    </div>
+
   </div>
 
-  <!-- DISCLAIMER -->
-  <div class="disc">
-    General education only. Whether an epidural is right and safe for you is decided by your doctor and anaesthetist. Always follow your own care team's advice.
-  </div>
-  <div class="foot"><a href="index.html" style="color:inherit;text-decoration:none;border-bottom:1px solid currentColor;padding-bottom:1px;">← Back to MiGynae</a> &nbsp;·&nbsp; © 2026 MiGynae</div>
-
-</div>
 </body>
 </html>

--- a/family-support-guide.html
+++ b/family-support-guide.html
@@ -3,206 +3,129 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>A Guide for the Family | MiGynae App</title>
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
-    <meta name="description" content="A guide for the family: how to understand and support her through pregnancy and after the baby arrives.">
-    <link rel="canonical" href="https://migynaeapp.com/family-support-guide.html">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://migynaeapp.com/family-support-guide.html">
-    <meta property="og:title" content="A Guide for the Family | MiGynae App">
-    <meta property="og:description" content="A guide for the family: how to understand and support her through pregnancy and after the baby arrives.">
-    <meta property="og:image" content="https://migynaeapp.com/images/logo.webp">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="A Guide for the Family | MiGynae App">
-    <meta name="twitter:description" content="A guide for the family: how to understand and support her through pregnancy and after the baby arrives.">
-<style>
-  :root{
-    --green:#2f4a3d; --cream:#faf6ee; --card:#ffffff; --ink:#3a352f; --muted:#7c756b; --line:#ece2d1;
-    --gold:#c8974a; --gold-tx:#a9781f; --gold-bg:#fbf3e4;
-    --serif:Georgia,'Times New Roman',serif;      /* -> Lora */
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; /* -> DM Sans */
-  }
-  *{box-sizing:border-box;margin:0;padding:0;}
-  body{background:#e3d9c7;font-family:var(--sans);color:var(--ink);display:flex;justify-content:center;padding:24px 12px;-webkit-font-smoothing:antialiased;}
-  .phone{width:390px;max-width:100%;background:var(--cream);border-radius:28px;overflow:hidden;box-shadow:0 12px 40px rgba(0,0,0,.18);}
-
-  .cta{background:var(--green);color:#fff;padding:18px 20px 20px;}
-  .cta.bottom{padding:22px 20px 26px;}
-  .cta h3{font-family:var(--serif);font-weight:600;font-size:16px;line-height:1.35;margin:6px 0 4px;}
-  .cta p{font-size:12.5px;color:#d9e5df;line-height:1.5;margin-bottom:14px;}
-  .stores{display:flex;gap:8px;}
-  .store{flex:1;display:flex;align-items:center;gap:8px;background:#fff;color:var(--green);text-decoration:none;padding:9px 10px;border-radius:11px;font-size:11px;font-weight:600;line-height:1.2;}
-  .store .ico{font-size:16px;line-height:1;}
-  .store small{display:block;font-size:8.5px;font-weight:500;color:var(--muted);letter-spacing:.3px;}
-
-  .logo-badge{width:40px;height:40px;border-radius:50%;background:#fff;padding:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,.12);}
-  .logo-badge img{width:100%;height:100%;object-fit:contain;border-radius:50%;}
-  .head .logo-badge{width:64px;height:64px;margin:0 auto 14px;}
-
-  .head{padding:24px 22px 6px;text-align:center;}
-  .kicker{font-size:10.5px;letter-spacing:1.6px;text-transform:uppercase;color:var(--gold-tx);font-weight:700;margin-bottom:8px;}
-  .head h1{font-family:var(--serif);font-weight:600;font-size:23px;line-height:1.28;color:var(--green);}
-  .head .sub{font-size:13px;color:var(--muted);line-height:1.6;margin-top:10px;}
-
-  .note{margin:16px 22px 4px;background:var(--gold-bg);border:1px solid #efe0c4;border-radius:14px;padding:14px 16px;}
-  .note p{font-family:var(--serif);font-style:italic;font-size:13.5px;line-height:1.6;color:#6d5a2f;}
-
-  .wrap{padding:16px 22px 6px;}
-  .block{background:var(--card);border:1px solid var(--line);border-left:4px solid var(--gold);border-radius:16px;padding:15px 16px 12px;margin-bottom:12px;}
-  .block.g{border-left-color:var(--green);}
-  .block h2{font-family:var(--serif);font-size:16px;font-weight:600;color:var(--green);margin-bottom:9px;}
-  .block ul{list-style:none;}
-  .block li{font-size:13px;line-height:1.5;color:var(--ink);padding:5px 0 5px 18px;position:relative;}
-  .block li::before{content:"";position:absolute;left:2px;top:9px;width:7px;height:7px;border-radius:50%;background:var(--gold);}
-  .block.g li::before{background:var(--green);}
-  .block .foot-line{font-size:11.5px;font-style:italic;color:var(--muted);margin-top:8px;padding-left:2px;}
-
-  .blogs{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:15px 16px 11px;margin-bottom:12px;}
-  .blogs .bh{font-family:var(--serif);font-size:16px;font-weight:600;color:var(--green);margin-bottom:3px;}
-  .blogs .bs{font-size:12px;color:var(--muted);line-height:1.45;margin-bottom:11px;}
-  .chip{display:inline-block;background:var(--gold-bg);color:var(--gold-tx);font-size:12px;font-weight:600;padding:7px 12px;border-radius:20px;margin:0 6px 7px 0;border:1px solid #efe0c4;}
-
-  .disc{padding:14px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
-  .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#b3a99c;}
-  /* ===== Desktop / web view: full-width page with a centered content column ===== */
-  @media (min-width: 768px){
-    body{ padding:0; }
-    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
-
-    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
-    .phone > *{
-      padding-left: max(24px, calc((100% - 760px) / 2));
-      padding-right: max(24px, calc((100% - 760px) / 2));
-    }
-    /* inset coloured cards become full-bleed bands too */
-    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
-    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
-    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
-
-    /* larger, web-friendly typography */
-    .head{ padding-top:52px; }
-    .head .logo-badge{ width:80px; height:80px; }
-    .head h1{ font-size:34px; line-height:1.2; }
-    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
-    .cta h3{ font-size:20px; }
-    .cta p{ font-size:14px; }
-    /* store buttons: natural badge size instead of stretching full width */
-    .stores{ gap:12px; justify-content:flex-start; }
-    .store{ flex:0 0 auto; width:210px; }
-    .sec-title{ font-size:22px; }
-    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
-    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
-    .disc{ font-size:12px; }
-  }
-
-</style>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<title>A Guide for the Family | MiGynae</title>
+<meta name="description" content="A guide for the family: how to understand and support her through pregnancy and after the baby arrives.">
+<link rel="canonical" href="https://migynaeapp.com/family-support-guide.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://migynaeapp.com/family-support-guide.html">
+<meta property="og:title" content="A Guide for the Family | MiGynae">
+<meta property="og:description" content="A guide for the family: how to understand and support her through pregnancy and after the baby arrives.">
+<meta property="og:image" content="https://migynaeapp.com/images/blog/postpartum-guide-banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="A Guide for the Family | MiGynae">
+<meta name="twitter:description" content="A guide for the family: how to understand and support her through pregnancy and after the baby arrives.">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="css/guide-page.css">
+<style>:root{--primary:#F4A4A3;--primary-dark:#e88a89;--primary-light:#fdf0f0;}</style>
 </head>
 <body>
-<div class="phone">
 
-  <!-- TOP APP CTA -->
-  <div class="cta">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Understand her journey, so you can support it</h3>
-    <p>Read the guides and FAQs in the MiGynae App, so the whole family knows what is normal and how to help.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+  <div class="hero">
+    <div class="hero-inner">
+      <div class="hero-brand">For the Family</div>
+      <h1>How to support her</h1>
+      <p class="hero-tagline">Someone you love is expecting. A little understanding from the people around her makes the whole journey easier. Here is how you can help.</p>
     </div>
   </div>
 
-  <!-- HEADER -->
-  <div class="head">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <div class="kicker">For the Family</div>
-    <h1>How to support her</h1>
-    <p class="sub">Someone you love is expecting. A little understanding from the people around her makes the whole journey easier. Here is how you can help.</p>
+  <div class="download-bar">
+    <a class="dl-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Download on Play Store</a>
+    <a class="dl-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
   </div>
 
-  <!-- BRAND NOTE -->
-  <div class="note">
-    <p>"Pregnancy is never carried by one woman alone. It is carried by everyone who loves her, and your support becomes part of her care."</p>
+  <div class="content">
+
+    <div class="note-quote">
+      "Pregnancy is never carried by one woman alone. It is carried by everyone who loves her, and your support becomes part of her care."
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">1</div><h2>Understand what she is feeling</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>Her body and hormones are changing every week. Tiredness, nausea and mood changes are <b>real, not drama</b>.</li>
+          <li>Some days she will glow, some days she will simply need to rest.</li>
+          <li>She may feel anxious about the baby and the delivery. Calm reassurance helps more than advice.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">2</div><h2>The support that helps most</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>Let her rest without guilt, and share the housework.</li>
+          <li>Help her eat well — simple home food that her body can handle.</li>
+          <li>Make sure she reaches every check-up.</li>
+          <li>Keep visitors few and gentle, especially when she is tired.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">3</div><h2>Please be gentle with words</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>Do not compare her pregnancy to anyone else's.</li>
+          <li>Do not share frightening birth stories with her.</li>
+          <li>Trust her doctor's advice over old remedies and myths.</li>
+          <li>Never make her feel pressure about the baby's gender. A healthy baby is the blessing.</li>
+        </ul>
+        <div class="reassure" style="margin-bottom:0;">
+          <p style="font-style:italic;">Kind words heal. Careless ones stay with her.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">4</div><h2>Read these to understand her better</h2></div>
+      <div class="section-body">
+        <p>A few guides in the MiGynae app the family can read too:</p>
+        <div class="chips">
+          <span class="chip">Breastfeeding Basics</span>
+          <span class="chip">What to Know When Labour Begins</span>
+          <span class="chip">Preparing for a Normal Delivery</span>
+          <span class="chip">Post-Delivery Recovery</span>
+          <span class="chip">Warning Signs: When to See a Doctor</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">5</div><h2>After the baby arrives</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>She will be healing and very short on sleep. Let her rest and recover.</li>
+          <li>Share the night duties and the baby's care, so it is not all on her.</li>
+          <li>Feed her well, especially while she is breastfeeding.</li>
+          <li>If she seems low, cries often, or pulls away, do not judge. Help her see her doctor — this is common and treatable.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="cta-section">
+      <h3>Support her, every step of the way</h3>
+      <p>Follow her pregnancy and read the guides together in the MiGynae app.</p>
+      <div class="cta-buttons">
+        <a class="cta-btn cta-btn-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Get it on Play Store</a>
+        <a class="cta-btn cta-btn-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
+      </div>
+    </div>
+
+    <div class="disclaimer">
+      General support tips. For any health concern, always follow her doctor's advice.
+    </div>
+
+    <div class="page-footer">
+      <a href="guides.html">&larr; All guides</a> &nbsp;&middot;&nbsp; <a href="index.html">MiGynae home</a><br>
+      &copy; 2026 MiGynae
+    </div>
+
   </div>
 
-  <div class="wrap">
-
-    <!-- 1 -->
-    <div class="block">
-      <h2>Understand what she is feeling</h2>
-      <ul>
-        <li>Her body and hormones are changing every week. Tiredness, nausea and mood changes are real, not drama.</li>
-        <li>Some days she will glow, some days she will simply need to rest.</li>
-        <li>She may feel anxious about the baby and the delivery. Calm reassurance helps more than advice.</li>
-      </ul>
-    </div>
-
-    <!-- 2 -->
-    <div class="block g">
-      <h2>The support that helps most</h2>
-      <ul>
-        <li>Let her rest without guilt, and share the housework.</li>
-        <li>Help her eat well, simple home food that her body can handle.</li>
-        <li>Make sure she reaches every check-up.</li>
-        <li>Keep visitors few and gentle, especially when she is tired.</li>
-      </ul>
-    </div>
-
-    <!-- 3 -->
-    <div class="block">
-      <h2>Please be gentle with words</h2>
-      <ul>
-        <li>Do not compare her pregnancy to anyone else's.</li>
-        <li>Do not share frightening birth stories with her.</li>
-        <li>Trust her doctor's advice over old remedies and myths.</li>
-        <li>Never make her feel pressure about the baby's gender. A healthy baby is the blessing.</li>
-      </ul>
-      <div class="foot-line">Kind words heal. Careless ones stay with her.</div>
-    </div>
-
-    <!-- BLOGS -->
-    <div class="blogs">
-      <div class="bh">Read these to understand her better</div>
-      <div class="bs">A few guides in the MiGynae App the family can read too:</div>
-      <span class="chip">Breastfeeding Basics</span>
-      <span class="chip">What to Know When Labour Begins</span>
-      <span class="chip">Preparing for a Normal Delivery</span>
-      <span class="chip">Post-Delivery Recovery</span>
-      <span class="chip">Warning Signs: When to See a Doctor</span>
-    </div>
-
-    <!-- 4 -->
-    <div class="block g">
-      <h2>After the baby arrives</h2>
-      <ul>
-        <li>She will be healing and very short on sleep. Let her rest and recover.</li>
-        <li>Share the night duties and the baby's care, so it is not all on her.</li>
-        <li>Feed her well, especially while she is breastfeeding.</li>
-        <li>If she seems low, cries often, or pulls away, do not judge. Help her see her doctor. This is common and treatable.</li>
-      </ul>
-    </div>
-
-  </div>
-
-  <!-- BOTTOM APP CTA -->
-  <div class="cta bottom">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Support her, every step of the way</h3>
-    <p>Follow her pregnancy and read the guides together in the MiGynae App.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
-    </div>
-  </div>
-
-  <!-- DISCLAIMER -->
-  <div class="disc">
-    General support tips. For any health concern, always follow her doctor's advice.
-  </div>
-  <div class="foot"><a href="index.html" style="color:inherit;text-decoration:none;border-bottom:1px solid currentColor;padding-bottom:1px;">← Back to MiGynae</a> &nbsp;·&nbsp; © 2026 MiGynae</div>
-
-</div>
 </body>
 </html>

--- a/guides.html
+++ b/guides.html
@@ -21,6 +21,22 @@
     <link rel="stylesheet" href="css/index.min.css">
     <link rel="stylesheet" href="css/landing.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <style>
+        .guides-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:24px;margin-top:40px;}
+        .guides-grid .guide-tile{display:flex;flex-direction:column;text-decoration:none;color:inherit;background:#fff;border:1px solid #f1f3f4;border-radius:20px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.05);transition:transform .3s ease,box-shadow .3s ease;}
+        .guides-grid .guide-tile:hover{transform:translateY(-6px);box-shadow:0 14px 30px rgba(0,0,0,.12);}
+        .guides-grid .guide-thumb{width:100%;height:180px;object-fit:cover;display:block;}
+        .guides-grid .guide-thumb-gradient{width:100%;height:180px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:#fff;text-align:center;padding:16px;position:relative;overflow:hidden;}
+        .guides-grid .guide-thumb-gradient::after{content:'';position:absolute;top:-30px;right:-30px;width:120px;height:120px;background:rgba(255,255,255,.12);border-radius:50%;}
+        .guides-grid .guide-thumb-gradient i{font-size:34px;position:relative;}
+        .guides-grid .guide-thumb-gradient .thumb-title{font-size:1.2rem;font-weight:800;line-height:1.2;letter-spacing:.3px;position:relative;}
+        .guides-grid .guide-tile-body{flex:1;display:flex;flex-direction:column;padding:22px;}
+        .guides-grid .guide-tile-body h2{font-size:1.2rem;margin:8px 0;color:var(--text-dark);}
+        .guides-grid .guide-tile-body p{flex:1;font-size:14.5px;color:var(--text-light);line-height:1.6;margin-bottom:16px;}
+        .guides-grid .guide-tile-body .read-link{font-weight:600;color:var(--primary-dark);font-size:14px;}
+        @media (max-width:900px){.guides-grid{grid-template-columns:repeat(2,1fr);}}
+        @media (max-width:600px){.guides-grid{grid-template-columns:1fr;}}
+    </style>
 </head>
 <body>
     <header>
@@ -48,81 +64,94 @@
         <div class="container">
             <span class="section-eyebrow">Free expert guides</span>
             <h1>Labour &amp; Postpartum Guides</h1>
-            <p>Comprehensive, medically reviewed guides plus quick reads for every stage — choose what you're preparing for. Read free on the web; use the app for daily tracking.</p>
+            <p>Free, medically reviewed guides for every stage of labour, birth and recovery — choose what you're preparing for. Read on the web; track in the app.</p>
         </div>
     </section>
 
     <main class="page-content">
         <section style="padding:0 0 80px;">
             <div class="container">
-                <div class="guide-options">
-                    <a href="labour-prep-guide.html" class="guide-option">
-                        <img src="images/blog/labour-guide-banner.png" alt="Labour preparation guide">
-                        <div class="guide-option-body">
+                <div class="guides-grid">
+                    <a href="labour-prep-guide.html" class="guide-tile">
+                        <img class="guide-thumb" src="images/blog/labour-guide-banner.png" alt="Labour prep guide" loading="lazy">
+                        <div class="guide-tile-body">
                             <span class="resource-tag">Before birth</span>
                             <h2>Labour Prep Guide</h2>
-                            <p>Prepare for normal delivery with OBGYN-backed tips on breathing techniques, labour positions, hospital bag checklist, pain management options, and birth partner support. Includes when to go to the hospital and realistic expectations for first-time mothers.</p>
-                            <span>Read full labour guide →</span>
+                            <p>Breathing, positions, hospital-bag checklist, pain-relief options and birth-partner support — plus when to head to hospital.</p>
+                            <span class="read-link">Read full guide →</span>
                         </div>
                     </a>
-                    <a href="postpartum-recovery-guide.html" class="guide-option">
-                        <img src="images/blog/postpartum-guide-banner.png" alt="Postpartum recovery guide">
-                        <div class="guide-option-body">
+                    <a href="postpartum-recovery-guide.html" class="guide-tile">
+                        <img class="guide-thumb" src="images/blog/postpartum-guide-banner.png" alt="Postpartum recovery guide" loading="lazy">
+                        <div class="guide-tile-body">
                             <span class="resource-tag">After birth</span>
                             <h2>Postpartum Recovery Guide</h2>
-                            <p>Heal after delivery with expert guidance on wound care (C-section &amp; vaginal), safe postpartum exercises, breastfeeding tips, nutrition for recovery, mental health support, and warning signs that need immediate medical attention.</p>
-                            <span>Read full recovery guide →</span>
+                            <p>Wound care, safe exercises, breastfeeding, recovery nutrition, mental health, and warning signs to watch for.</p>
+                            <span class="read-link">Read full guide →</span>
                         </div>
                     </a>
-                </div>
-
-                <div class="section-header" style="margin-top:72px;margin-bottom:32px;">
-                    <span class="section-eyebrow">Quick guides</span>
-                    <h2>Short, Shareable Reads</h2>
-                    <p>Bite-size, doctor-backed guides for labour, birth, recovery, and the people supporting her — quick to read and easy to share.</p>
-                </div>
-                <div class="brief-grid">
-                    <a href="pre-labour-prep-guide.html" class="brief-card">
-                        <div class="brief-card-icon"><i class="fas fa-person-walking"></i></div>
-                        <h3>Pre-Labour Prep</h3>
-                        <p>Stay active, know when to step it up from 28 weeks, questions for your doctor, and hospital warning signs.</p>
-                        <span class="read-more">Read guide <i class="fas fa-arrow-right"></i></span>
+                    <a href="pre-labour-prep-guide.html" class="guide-tile">
+                        <div class="guide-thumb-gradient" style="background:linear-gradient(135deg,#D5B6DA,#b98ec0)"><i class="fas fa-person-walking"></i><span class="thumb-title">Pre-Labour Prep</span></div>
+                        <div class="guide-tile-body">
+                            <span class="resource-tag">Before birth</span>
+                            <h2>Pre-Labour Prep</h2>
+                            <p>Stay active, know when to step it up from 28 weeks, questions for your doctor, and hospital warning signs.</p>
+                            <span class="read-link">Read guide →</span>
+                        </div>
                     </a>
-                    <a href="during-labour-guide.html" class="brief-card">
-                        <div class="brief-card-icon"><i class="fas fa-heart-pulse"></i></div>
-                        <h3>During Labour</h3>
-                        <p>Breathing, positions, when not to push, resting between contractions, and asking for pain relief.</p>
-                        <span class="read-more">Read guide <i class="fas fa-arrow-right"></i></span>
+                    <a href="during-labour-guide.html" class="guide-tile">
+                        <div class="guide-thumb-gradient" style="background:linear-gradient(135deg,#D5B6DA,#b98ec0)"><i class="fas fa-heart-pulse"></i><span class="thumb-title">During Labour</span></div>
+                        <div class="guide-tile-body">
+                            <span class="resource-tag">During birth</span>
+                            <h2>During Labour</h2>
+                            <p>Breathing, positions, when not to push, resting between contractions, and asking for pain relief.</p>
+                            <span class="read-link">Read guide →</span>
+                        </div>
                     </a>
-                    <a href="epidural-guide.html" class="brief-card">
-                        <div class="brief-card-icon"><i class="fas fa-syringe"></i></div>
-                        <h3>The Epidural, Explained</h3>
-                        <p>What it is, what to expect, myths vs facts, and the right questions to ask your anaesthetist.</p>
-                        <span class="read-more">Read guide <i class="fas fa-arrow-right"></i></span>
+                    <a href="epidural-guide.html" class="guide-tile">
+                        <div class="guide-thumb-gradient" style="background:linear-gradient(135deg,#D5B6DA,#b98ec0)"><i class="fas fa-syringe"></i><span class="thumb-title">The Epidural</span></div>
+                        <div class="guide-tile-body">
+                            <span class="resource-tag">Pain relief</span>
+                            <h2>The Epidural, Explained</h2>
+                            <p>What it is, what to expect, myths vs facts, and the right questions to ask your anaesthetist.</p>
+                            <span class="read-link">Read guide →</span>
+                        </div>
                     </a>
-                    <a href="caesarean-guide.html" class="brief-card">
-                        <div class="brief-card-icon"><i class="fas fa-notes-medical"></i></div>
-                        <h3>Your Caesarean Guide</h3>
-                        <p>The essentials of a C-section (LSCS), recovering well, warning signs, and reassurance it's still your birth.</p>
-                        <span class="read-more">Read guide <i class="fas fa-arrow-right"></i></span>
+                    <a href="caesarean-guide.html" class="guide-tile">
+                        <div class="guide-thumb-gradient" style="background:linear-gradient(135deg,#D5B6DA,#b98ec0)"><i class="fas fa-notes-medical"></i><span class="thumb-title">Caesarean Guide</span></div>
+                        <div class="guide-tile-body">
+                            <span class="resource-tag">C-section</span>
+                            <h2>Your Caesarean Guide</h2>
+                            <p>The essentials of a C-section (LSCS), recovering well, warning signs, and reassurance it's still your birth.</p>
+                            <span class="read-link">Read guide →</span>
+                        </div>
                     </a>
-                    <a href="post-delivery-guide.html" class="brief-card">
-                        <div class="brief-card-icon"><i class="fas fa-heart"></i></div>
-                        <h3>Post-Delivery Recovery</h3>
-                        <p>What's normal and what's not, warning signs, and simple do's and don'ts after birth.</p>
-                        <span class="read-more">Read guide <i class="fas fa-arrow-right"></i></span>
+                    <a href="post-delivery-guide.html" class="guide-tile">
+                        <div class="guide-thumb-gradient" style="background:linear-gradient(135deg,#F4A4A3,#e88a89)"><i class="fas fa-heart"></i><span class="thumb-title">Post-Delivery</span></div>
+                        <div class="guide-tile-body">
+                            <span class="resource-tag">After birth</span>
+                            <h2>Post-Delivery Recovery</h2>
+                            <p>What's normal and what's not, warning signs, and simple do's and don'ts after birth.</p>
+                            <span class="read-link">Read guide →</span>
+                        </div>
                     </a>
-                    <a href="partner-support-guide.html" class="brief-card">
-                        <div class="brief-card-icon"><i class="fas fa-hands-holding"></i></div>
-                        <h3>For the Partner</h3>
-                        <p>How to support her through pregnancy, in the labour room, and after the baby comes.</p>
-                        <span class="read-more">Read guide <i class="fas fa-arrow-right"></i></span>
+                    <a href="partner-support-guide.html" class="guide-tile">
+                        <div class="guide-thumb-gradient" style="background:linear-gradient(135deg,#F4A4A3,#e88a89)"><i class="fas fa-hands-holding"></i><span class="thumb-title">For the Partner</span></div>
+                        <div class="guide-tile-body">
+                            <span class="resource-tag">Support</span>
+                            <h2>For the Partner</h2>
+                            <p>How to support her through pregnancy, in the labour room, and after the baby comes.</p>
+                            <span class="read-link">Read guide →</span>
+                        </div>
                     </a>
-                    <a href="family-support-guide.html" class="brief-card">
-                        <div class="brief-card-icon"><i class="fas fa-people-roof"></i></div>
-                        <h3>For the Family</h3>
-                        <p>How to understand and support her through pregnancy and after the baby arrives.</p>
-                        <span class="read-more">Read guide <i class="fas fa-arrow-right"></i></span>
+                    <a href="family-support-guide.html" class="guide-tile">
+                        <div class="guide-thumb-gradient" style="background:linear-gradient(135deg,#F4A4A3,#e88a89)"><i class="fas fa-users"></i><span class="thumb-title">For the Family</span></div>
+                        <div class="guide-tile-body">
+                            <span class="resource-tag">Support</span>
+                            <h2>For the Family</h2>
+                            <p>How to understand and support her through pregnancy and after the baby arrives.</p>
+                            <span class="read-link">Read guide →</span>
+                        </div>
                     </a>
                 </div>
 

--- a/partner-support-guide.html
+++ b/partner-support-guide.html
@@ -3,185 +3,112 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>A Little Guide for the Partner | MiGynae App</title>
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
-    <meta name="description" content="A little guide for the partner: how to support her through pregnancy, in the labour room, and after the baby comes.">
-    <link rel="canonical" href="https://migynaeapp.com/partner-support-guide.html">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://migynaeapp.com/partner-support-guide.html">
-    <meta property="og:title" content="A Little Guide for the Partner | MiGynae App">
-    <meta property="og:description" content="A little guide for the partner: how to support her through pregnancy, in the labour room, and after the baby comes.">
-    <meta property="og:image" content="https://migynaeapp.com/images/logo.webp">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="A Little Guide for the Partner | MiGynae App">
-    <meta name="twitter:description" content="A little guide for the partner: how to support her through pregnancy, in the labour room, and after the baby comes.">
-<style>
-  :root{
-    --beige:#fdf8f0; --card:#ffffff; --ink:#4a413b; --muted:#8a827a; --line:#efe7d8;
-    --pink:#d98aa4; --pink-bg:#fbeef2; --pink-tx:#b25e7c;
-    --blue:#7ba7cc; --blue-bg:#eef4fa; --blue-tx:#4d7aa1;
-    --serif:Georgia,'Times New Roman',serif;      /* -> Lora */
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; /* -> DM Sans */
-  }
-  *{box-sizing:border-box;margin:0;padding:0;}
-  body{background:#e9e0d2;font-family:var(--sans);color:var(--ink);display:flex;justify-content:center;padding:24px 12px;-webkit-font-smoothing:antialiased;}
-  .phone{width:390px;max-width:100%;background:var(--beige);border-radius:28px;overflow:hidden;box-shadow:0 12px 40px rgba(0,0,0,.18);}
-
-  .cta{background:linear-gradient(135deg,var(--pink-bg),var(--blue-bg));padding:18px 20px 20px;border-bottom:1px solid var(--line);}
-  .cta.bottom{border-bottom:none;border-top:1px solid var(--line);padding:22px 20px 26px;}
-  .cta h3{font-family:var(--serif);font-weight:600;font-size:16px;line-height:1.35;margin:6px 0 4px;color:var(--ink);}
-  .cta p{font-size:12.5px;color:var(--muted);line-height:1.5;margin-bottom:14px;}
-  .stores{display:flex;gap:8px;}
-  .store{flex:1;display:flex;align-items:center;gap:8px;background:#fff;color:var(--ink);text-decoration:none;padding:9px 10px;border-radius:11px;font-size:11px;font-weight:600;line-height:1.2;box-shadow:0 1px 4px rgba(0,0,0,.06);}
-  .store .ico{font-size:15px;line-height:1;color:var(--pink-tx);}
-  .store small{display:block;font-size:8.5px;font-weight:500;color:var(--muted);letter-spacing:.3px;}
-
-  .logo-badge{width:40px;height:40px;border-radius:50%;background:#fff;padding:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,.10);}
-  .logo-badge img{width:100%;height:100%;object-fit:contain;border-radius:50%;}
-  .head .logo-badge{width:64px;height:64px;margin:0 auto 14px;}
-
-  .head{padding:24px 22px 8px;text-align:center;}
-  .kicker{font-size:10.5px;letter-spacing:1.6px;text-transform:uppercase;color:var(--pink-tx);font-weight:700;margin-bottom:8px;}
-  .head h1{font-family:var(--serif);font-weight:600;font-size:23px;line-height:1.28;color:var(--ink);}
-  .head .sub{font-size:13px;color:var(--muted);line-height:1.6;margin-top:10px;}
-
-  .wrap{padding:18px 22px 6px;}
-  .block{background:var(--card);border:1px solid var(--line);border-left:4px solid var(--pink);border-radius:16px;padding:15px 16px 12px;margin-bottom:12px;}
-  .block.blue{border-left-color:var(--blue);}
-  .block h2{font-family:var(--serif);font-size:16px;font-weight:600;color:var(--pink-tx);margin-bottom:9px;display:flex;align-items:center;gap:7px;}
-  .block.blue h2{color:var(--blue-tx);}
-  .block .hrt{font-size:13px;}
-  .block ul{list-style:none;}
-  .block li{font-size:13px;line-height:1.5;color:var(--ink);padding:5px 0 5px 18px;position:relative;}
-  .block li::before{content:"♥";position:absolute;left:0;top:5px;font-size:9px;color:var(--pink);}
-  .block.blue li::before{color:var(--blue);}
-  .block .foot-line{font-size:11.5px;font-style:italic;color:var(--muted);margin-top:8px;padding-left:2px;}
-
-  .disc{padding:14px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
-  .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#b3a99c;}
-  /* ===== Desktop / web view: full-width page with a centered content column ===== */
-  @media (min-width: 768px){
-    body{ padding:0; }
-    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
-
-    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
-    .phone > *{
-      padding-left: max(24px, calc((100% - 760px) / 2));
-      padding-right: max(24px, calc((100% - 760px) / 2));
-    }
-    /* inset coloured cards become full-bleed bands too */
-    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
-    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
-    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
-
-    /* larger, web-friendly typography */
-    .head{ padding-top:52px; }
-    .head .logo-badge{ width:80px; height:80px; }
-    .head h1{ font-size:34px; line-height:1.2; }
-    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
-    .cta h3{ font-size:20px; }
-    .cta p{ font-size:14px; }
-    /* store buttons: natural badge size instead of stretching full width */
-    .stores{ gap:12px; justify-content:flex-start; }
-    .store{ flex:0 0 auto; width:210px; }
-    .sec-title{ font-size:22px; }
-    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
-    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
-    .disc{ font-size:12px; }
-  }
-
-</style>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<title>A Guide for the Partner | MiGynae</title>
+<meta name="description" content="A guide for the partner: how to support her through pregnancy, in the labour room, and after the baby comes.">
+<link rel="canonical" href="https://migynaeapp.com/partner-support-guide.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://migynaeapp.com/partner-support-guide.html">
+<meta property="og:title" content="A Guide for the Partner | MiGynae">
+<meta property="og:description" content="A guide for the partner: how to support her through pregnancy, in the labour room, and after the baby comes.">
+<meta property="og:image" content="https://migynaeapp.com/images/blog/postpartum-guide-banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="A Guide for the Partner | MiGynae">
+<meta name="twitter:description" content="A guide for the partner: how to support her through pregnancy, in the labour room, and after the baby comes.">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="css/guide-page.css">
+<style>:root{--primary:#F4A4A3;--primary-dark:#e88a89;--primary-light:#fdf0f0;}</style>
 </head>
 <body>
-<div class="phone">
 
-  <!-- TOP APP CTA -->
-  <div class="cta">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Want to really understand what she is going through?</h3>
-    <p>Read the blogs and FAQs together in the MiGynae App.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+  <div class="hero">
+    <div class="hero-inner">
+      <div class="hero-brand">For the Partner</div>
+      <h1>How to be her greatest support</h1>
+      <p class="hero-tagline">She is carrying your baby through months of change. Your support matters more than you know, and the small things count the most.</p>
     </div>
   </div>
 
-  <!-- HEADER -->
-  <div class="head">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <div class="kicker">For the Partner</div>
-    <h1>How to be her greatest support</h1>
-    <p class="sub">She is carrying your baby through months of change. Your support matters more than you know, and the small things count the most.</p>
+  <div class="download-bar">
+    <a class="dl-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Download on Play Store</a>
+    <a class="dl-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
   </div>
 
-  <div class="wrap">
+  <div class="content">
 
-    <!-- 1 -->
-    <div class="block">
-      <h2><span class="hrt">♥</span> The little things mean everything</h2>
-      <ul>
-        <li>Listen. Often she needs to be heard, not fixed.</li>
-        <li>Take chores off her plate before she asks.</li>
-        <li>Come along to the check-ups when you can.</li>
-        <li>Be patient. Hormones make moods swing, it is not about you.</li>
-      </ul>
+    <div class="intro-card">
+      You do not have to fix everything. Being present, patient and informed is the support she will remember most.
     </div>
 
-    <!-- 2 -->
-    <div class="block blue">
-      <h2><span class="hrt">♥</span> Learn with her</h2>
-      <ul>
-        <li>Open the MiGynae App and read the FAQs and blogs, on things like labour pain, acidity, leg swelling and sleep.</li>
-        <li>Once you know what is normal and what is a warning sign, you can calm her worries instead of adding to them.</li>
-        <li>Gently remind her about her medicines, her water, and her rest.</li>
-      </ul>
-      <div class="foot-line">A partner who knows is a partner who helps.</div>
+    <div class="section">
+      <div class="section-header"><div class="section-number">1</div><h2>The little things mean everything</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>Listen. Often she needs to be <b>heard, not fixed</b>.</li>
+          <li>Take chores off her plate before she asks.</li>
+          <li>Come along to the check-ups when you can.</li>
+          <li>Be patient. Hormones make moods swing — it is not about you.</li>
+        </ul>
+      </div>
     </div>
 
-    <!-- 3 -->
-    <div class="block">
-      <h2><span class="hrt">♥</span> In the labour room</h2>
-      <ul>
-        <li>Stay calm. Your calm becomes her calm.</li>
-        <li>Breathe with her, and hold her hand.</li>
-        <li>Help her change positions, and speak up for her to the team.</li>
-        <li>If she snaps, do not take it to heart. She is working incredibly hard.</li>
-      </ul>
+    <div class="section">
+      <div class="section-header"><div class="section-number">2</div><h2>Learn with her</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>Open the MiGynae app and read the FAQs and blogs — on things like labour pain, acidity, leg swelling and sleep.</li>
+          <li>Once you know what is normal and what is a warning sign, you can <b>calm her worries</b> instead of adding to them.</li>
+          <li>Gently remind her about her medicines, her water, and her rest.</li>
+        </ul>
+      </div>
     </div>
 
-    <!-- 4 -->
-    <div class="block blue">
-      <h2><span class="hrt">♥</span> After the baby comes</h2>
-      <ul>
-        <li>She is healing and running on little sleep, take the night shift when you can.</li>
-        <li>Bring her water and food, especially while she is feeding.</li>
-        <li>Watch for lasting sadness or anxiety. Postpartum depression is real, help her reach her doctor early.</li>
-        <li>You are a team. She should never feel she is doing this alone.</li>
-      </ul>
+    <div class="section">
+      <div class="section-header"><div class="section-number">3</div><h2>In the labour room</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>Stay calm. <b>Your calm becomes her calm.</b></li>
+          <li>Breathe with her, and hold her hand.</li>
+          <li>Help her change positions, and speak up for her to the team.</li>
+          <li>If she snaps, do not take it to heart. She is working incredibly hard.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">4</div><h2>After the baby comes</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>She is healing and running on little sleep — take the night shift when you can.</li>
+          <li>Bring her water and food, especially while she is feeding.</li>
+          <li>Watch for lasting sadness or anxiety. <b>Postpartum depression is real</b> — help her reach her doctor early.</li>
+          <li>You are a team. She should never feel she is doing this alone.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="cta-section">
+      <h3>Be the partner she will always remember</h3>
+      <p>Go through the blogs, FAQs and trackers together in the MiGynae app.</p>
+      <div class="cta-buttons">
+        <a class="cta-btn cta-btn-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Get it on Play Store</a>
+        <a class="cta-btn cta-btn-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
+      </div>
+    </div>
+
+    <div class="disclaimer">
+      General support tips. For any health concern, always follow her doctor's advice.
+    </div>
+
+    <div class="page-footer">
+      <a href="guides.html">&larr; All guides</a> &nbsp;&middot;&nbsp; <a href="index.html">MiGynae home</a><br>
+      &copy; 2026 MiGynae
     </div>
 
   </div>
 
-  <!-- BOTTOM APP CTA -->
-  <div class="cta bottom">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Be the partner she will always remember</h3>
-    <p>Go through the blogs, FAQs and trackers together in the MiGynae App.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
-    </div>
-  </div>
-
-  <!-- DISCLAIMER -->
-  <div class="disc">
-    General support tips. For any health concern, always follow her doctor's advice.
-  </div>
-  <div class="foot"><a href="index.html" style="color:inherit;text-decoration:none;border-bottom:1px solid currentColor;padding-bottom:1px;">← Back to MiGynae</a> &nbsp;·&nbsp; © 2026 MiGynae</div>
-
-</div>
 </body>
 </html>

--- a/post-delivery-guide.html
+++ b/post-delivery-guide.html
@@ -3,256 +3,63 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Post-Delivery Recovery — Quick Guide | MiGynae</title>
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
-    <meta name="description" content="A quick post-delivery recovery guide: what&#x27;s normal and what&#x27;s not, warning signs, and simple do&#x27;s and don&#x27;ts after a normal or caesarean birth.">
-    <link rel="canonical" href="https://migynaeapp.com/post-delivery-guide.html">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://migynaeapp.com/post-delivery-guide.html">
-    <meta property="og:title" content="Post-Delivery Recovery — Quick Guide | MiGynae">
-    <meta property="og:description" content="A quick post-delivery recovery guide: what&#x27;s normal and what&#x27;s not, warning signs, and simple do&#x27;s and don&#x27;ts after a normal or caesarean birth.">
-    <meta property="og:image" content="https://migynaeapp.com/images/logo.webp">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Post-Delivery Recovery — Quick Guide | MiGynae">
-    <meta name="twitter:description" content="A quick post-delivery recovery guide: what&#x27;s normal and what&#x27;s not, warning signs, and simple do&#x27;s and don&#x27;ts after a normal or caesarean birth.">
-<style>
-  :root{
-    --green:#2f4a3d;
-    --green-soft:#3f5e4f;
-    --cream:#faf6ee;
-    --card:#ffffff;
-    --ink:#2c2622;
-    --muted:#6b655d;
-    --line:#e7ded0;
-    --gold:#c8974a;
-    --rose:#b6524c;
-    --rose-bg:#fbeeed;
-    --ok:#3f7a5a;
-    --ok-bg:#eef5f0;
-    --serif:Georgia,'Times New Roman',serif;      /* → Lora */
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; /* → DM Sans */
-  }
-  *{box-sizing:border-box;margin:0;padding:0;}
-  body{
-    background:#d9d3c7;
-    font-family:var(--sans);
-    color:var(--ink);
-    display:flex;justify-content:center;
-    padding:24px 12px;
-    -webkit-font-smoothing:antialiased;
-  }
-  .phone{
-    width:390px;max-width:100%;
-    background:var(--cream);
-    border-radius:28px;
-    overflow:hidden;
-    box-shadow:0 12px 40px rgba(0,0,0,.18);
-  }
-
-  /* ---- App CTA band ---- */
-  .cta{
-    background:var(--green);
-    color:#fff;
-    padding:18px 20px 20px;
-  }
-  .cta.bottom{padding:22px 20px 26px;}
-  .cta .flower{font-size:15px;}
-  .cta h3{
-    font-family:var(--serif);
-    font-weight:600;
-    font-size:16px;
-    line-height:1.35;
-    margin:6px 0 4px;
-  }
-  .cta p{font-size:12.5px;color:#d9e5df;line-height:1.5;margin-bottom:14px;}
-  .stores{display:flex;gap:8px;}
-  .store{
-    flex:1;
-    display:flex;align-items:center;gap:8px;
-    background:#fff;color:var(--green);
-    text-decoration:none;
-    padding:9px 10px;border-radius:11px;
-    font-size:11px;font-weight:600;line-height:1.2;
-  }
-  .store .ico{font-size:16px;line-height:1;}
-  .store small{display:block;font-size:8.5px;font-weight:500;color:var(--muted);letter-spacing:.3px;}
-  .logo-badge{width:40px;height:40px;border-radius:50%;background:#fff;padding:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,.12);}
-  .logo-badge img{width:100%;height:100%;object-fit:contain;border-radius:50%;}
-  .head .logo-badge{width:64px;height:64px;margin:0 auto 14px;}
-
-  /* ---- Header ---- */
-  .head{padding:22px 22px 6px;text-align:center;}
-  .kicker{
-    font-size:10.5px;letter-spacing:1.6px;text-transform:uppercase;
-    color:var(--gold);font-weight:700;margin-bottom:8px;
-  }
-  .head h1{
-    font-family:var(--serif);font-weight:600;
-    font-size:23px;line-height:1.25;color:var(--green);
-  }
-  .head .sub{
-    font-size:13px;color:var(--muted);line-height:1.55;
-    margin-top:10px;
-  }
-
-  /* ---- Sections ---- */
-  .sec{padding:20px 22px 4px;}
-  .sec-title{
-    font-family:var(--serif);font-size:17px;font-weight:600;
-    color:var(--green);margin-bottom:12px;
-    display:flex;align-items:center;gap:8px;
-  }
-
-  /* normal vs not — two-tone rows */
-  .row{
-    background:var(--card);border:1px solid var(--line);
-    border-radius:13px;padding:13px 14px;margin-bottom:10px;
-  }
-  .tag{
-    display:inline-block;font-size:10px;font-weight:700;
-    letter-spacing:.5px;text-transform:uppercase;
-    padding:3px 9px;border-radius:20px;margin-bottom:7px;
-  }
-  .tag.ok{background:var(--ok-bg);color:var(--ok);}
-  .tag.no{background:var(--rose-bg);color:var(--rose);}
-  .row p{font-size:13px;line-height:1.5;color:var(--ink);}
-  .row p b{color:var(--green);}
-
-  /* warning box */
-  .warn{
-    background:var(--rose-bg);
-    border:1px solid #f0d3d1;
-    border-radius:15px;
-    padding:16px 16px 6px;
-  }
-  .warn .wt{
-    font-family:var(--serif);font-size:16px;font-weight:600;
-    color:var(--rose);margin-bottom:4px;
-  }
-  .warn .ws{font-size:11.5px;color:#9a5450;margin-bottom:12px;}
-  .warn ul{list-style:none;}
-  .warn li{
-    font-size:13px;line-height:1.45;color:var(--ink);
-    padding:7px 0 7px 24px;position:relative;
-    border-top:1px solid #f2dcda;
-  }
-  .warn li:first-child{border-top:none;}
-  .warn li::before{
-    content:"•";color:var(--rose);font-weight:700;
-    position:absolute;left:8px;top:6px;font-size:15px;
-  }
-
-  /* do / avoid two columns */
-  .cols{display:flex;gap:10px;}
-  .col{flex:1;background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 13px 6px;}
-  .col h4{font-size:12px;font-weight:700;letter-spacing:.4px;text-transform:uppercase;margin-bottom:9px;}
-  .col.do h4{color:var(--ok);}
-  .col.no h4{color:var(--rose);}
-  .col ul{list-style:none;}
-  .col li{font-size:12px;line-height:1.4;color:var(--ink);padding:5px 0 5px 15px;position:relative;}
-  .col li::before{position:absolute;left:0;top:5px;font-weight:700;}
-  .col.do li::before{content:"✓";color:var(--ok);}
-  .col.no li::before{content:"✕";color:var(--rose);}
-
-  /* more in app tease */
-  .more{
-    margin:18px 22px 4px;
-    background:var(--green);border-radius:15px;
-    padding:18px 18px 16px;color:#fff;
-  }
-  .more h3{font-family:var(--serif);font-size:16px;font-weight:600;margin-bottom:4px;}
-  .more .msub{font-size:12px;color:#cfe0d8;margin-bottom:12px;}
-  .more ul{list-style:none;}
-  .more li{
-    font-size:13px;line-height:1.4;padding:8px 0 8px 22px;
-    position:relative;border-top:1px solid rgba(255,255,255,.12);
-  }
-  .more li:first-child{border-top:none;}
-  .more li::before{content:"→";position:absolute;left:4px;color:var(--gold);font-weight:700;}
-
-  .disc{
-    padding:16px 22px 4px;font-size:10.5px;line-height:1.5;
-    color:var(--muted);text-align:center;
-  }
-  .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
-  /* ===== Desktop / web view: full-width page with a centered content column ===== */
-  @media (min-width: 768px){
-    body{ padding:0; }
-    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
-
-    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
-    .phone > *{
-      padding-left: max(24px, calc((100% - 760px) / 2));
-      padding-right: max(24px, calc((100% - 760px) / 2));
-    }
-    /* inset coloured cards become full-bleed bands too */
-    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
-    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
-    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
-
-    /* larger, web-friendly typography */
-    .head{ padding-top:52px; }
-    .head .logo-badge{ width:80px; height:80px; }
-    .head h1{ font-size:34px; line-height:1.2; }
-    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
-    .cta h3{ font-size:20px; }
-    .cta p{ font-size:14px; }
-    /* store buttons: natural badge size instead of stretching full width */
-    .stores{ gap:12px; justify-content:flex-start; }
-    .store{ flex:0 0 auto; width:210px; }
-    .sec-title{ font-size:22px; }
-    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
-    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
-    .disc{ font-size:12px; }
-  }
-
-</style>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<title>Post-Delivery Recovery Guide | MiGynae</title>
+<meta name="description" content="A post-delivery recovery guide: what's normal and what's not, warning signs, and simple do's and don'ts after a normal or caesarean birth.">
+<link rel="canonical" href="https://migynaeapp.com/post-delivery-guide.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://migynaeapp.com/post-delivery-guide.html">
+<meta property="og:title" content="Post-Delivery Recovery Guide | MiGynae">
+<meta property="og:description" content="A post-delivery recovery guide: what's normal and what's not, warning signs, and simple do's and don'ts after a normal or caesarean birth.">
+<meta property="og:image" content="https://migynaeapp.com/images/blog/postpartum-guide-banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Post-Delivery Recovery Guide | MiGynae">
+<meta name="twitter:description" content="A post-delivery recovery guide: what's normal and what's not, warning signs, and simple do's and don'ts after a normal or caesarean birth.">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="css/guide-page.css">
+<style>:root{--primary:#F4A4A3;--primary-dark:#e88a89;--primary-light:#fdf0f0;}</style>
 </head>
 <body>
-<div class="phone">
 
-  <!-- TOP APP CTA -->
-  <div class="cta">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Your full recovery guide lives in the MiGynae app</h3>
-    <p>Track healing, feeding &amp; baby growth — with doctor-backed daily guidance.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+  <div class="hero">
+    <div class="hero-inner">
+      <div class="hero-brand">Post-Delivery Care</div>
+      <h1>Recovery, made simple</h1>
+      <p class="hero-tagline">No one prepares you for this part. Whether you had a normal delivery or a caesarean, these recovery principles apply to both — save this for what's normal, what's not, and when to get help.</p>
     </div>
   </div>
 
-  <!-- HEADER -->
-  <div class="head">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <div class="kicker">Post-Delivery Care</div>
-    <h1>Recovery, made simple</h1>
-    <p class="sub">No one prepares you for this part. Whether you had a normal delivery (NVD) or a caesarean (LSCS), these recovery principles apply to both. Save this for what's normal, what's not, and when to get help.</p>
+  <div class="download-bar">
+    <a class="dl-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Download on Play Store</a>
+    <a class="dl-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
   </div>
 
-  <!-- NORMAL VS NOT -->
-  <div class="sec">
-    <div class="sec-title">What's normal — and what's not</div>
+  <div class="content">
 
-    <div class="row">
-      <span class="tag ok">Normal</span>
-      <p>Bleeding like a heavy period, and cramps as the uterus shrinks. Discharge (lochia) fades over weeks: <b>red → pink → brown → yellow</b>.</p>
+    <div class="intro-card">
+      Your body has done something extraordinary and now it heals. Knowing what's normal takes the worry out of the early weeks.
     </div>
 
-    <div class="row">
-      <span class="tag no">Not normal — get care</span>
-      <p>Soaking a pad <b>every hour</b>, foul-smelling discharge, or large clots. Tell your gynaecologist.</p>
+    <div class="section">
+      <div class="section-header"><div class="section-number">1</div><h2>What's normal — and what's not</h2></div>
+      <div class="section-body">
+        <div class="card ok">
+          <div class="card-title"><i class="fas fa-check-circle"></i> Normal</div>
+          <p>Bleeding like a heavy period, and cramps as the uterus shrinks. Discharge (lochia) fades over weeks: <strong>red &rarr; pink &rarr; brown &rarr; yellow</strong>.</p>
+        </div>
+        <div class="card no">
+          <div class="card-title"><i class="fas fa-circle-exclamation"></i> Not normal — get care</div>
+          <p>Soaking a pad <strong>every hour</strong>, foul-smelling discharge, or large clots. Tell your gynaecologist.</p>
+        </div>
+      </div>
     </div>
-  </div>
 
-  <!-- WARNING SIGNS -->
-  <div class="sec">
-    <div class="warn">
-      <div class="wt">🚨 Get medical help now if you notice</div>
-      <div class="ws">Any one of these — don't wait it out.</div>
+    <div class="warning-box">
+      <div class="warning-title"><i class="fas fa-triangle-exclamation"></i> Get medical help now if you notice</div>
+      <p style="font-size:.9rem;margin-bottom:8px;color:var(--text-light)">Any one of these — don't wait it out.</p>
       <ul>
         <li>Heavy bleeding — a pad soaked within an hour</li>
         <li>Fever</li>
@@ -262,65 +69,67 @@
         <li>Severe difficulty sitting or walking</li>
       </ul>
     </div>
-  </div>
 
-  <!-- DO / AVOID -->
-  <div class="sec">
-    <div class="sec-title">Quick do's &amp; don'ts</div>
-    <div class="cols">
-      <div class="col do">
-        <h4>Do</h4>
-        <ul>
-          <li>Keep sipping fluids</li>
-          <li>Start gentle walking (as advised)</li>
-          <li>Kegels daily</li>
-          <li>Bend from the knees to lift baby</li>
-          <li>Clean front to back</li>
-        </ul>
+    <div class="section">
+      <div class="section-header"><div class="section-number">2</div><h2>Quick do's &amp; don'ts</h2></div>
+      <div class="section-body">
+        <div class="two-col">
+          <div class="card ok">
+            <div class="card-title"><i class="fas fa-check"></i> Do</div>
+            <ul class="check-list">
+              <li>Keep sipping fluids</li>
+              <li>Start gentle walking (as advised)</li>
+              <li>Kegels daily</li>
+              <li>Bend from the knees to lift baby</li>
+              <li>Clean front to back</li>
+            </ul>
+          </div>
+          <div class="card no">
+            <div class="card-title"><i class="fas fa-xmark"></i> Avoid</div>
+            <ul class="cross-list">
+              <li>Tight waistbands over stitches</li>
+              <li>Straining / constipation</li>
+              <li>A wet or sweaty incision</li>
+              <li>Ignoring worsening pain</li>
+              <li>Complete bed rest</li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="col no">
-        <h4>Avoid</h4>
-        <ul>
-          <li>Tight waistbands over stitches</li>
-          <li>Straining / constipation</li>
-          <li>A wet or sweaty incision</li>
-          <li>Ignoring worsening pain</li>
-          <li>Complete bed rest</li>
+    </div>
+
+    <div class="section">
+      <div class="section-header"><div class="section-number">3</div><h2>More inside the full app guide</h2></div>
+      <div class="section-body">
+        <ul class="dot-list">
+          <li>Wound care — episiotomy vs C-section, step by step</li>
+          <li>Week-by-week recovery exercises (2–6 &amp; 6–10 weeks)</li>
+          <li>Eat to recover — a postpartum diet plan</li>
+          <li>Breastfeeding — is baby getting enough milk?</li>
+          <li>Your mental health &amp; postpartum depression support</li>
         </ul>
       </div>
     </div>
-  </div>
 
-  <!-- MORE IN APP -->
-  <div class="more">
-    <h3>The full guide is in the app</h3>
-    <div class="msub">Everything above, plus the parts too detailed to fit here:</div>
-    <ul>
-      <li>Wound care — episiotomy vs C-section, step by step</li>
-      <li>Week-by-week recovery exercises (2–6 &amp; 6–10 weeks)</li>
-      <li>Eat to recover — a postpartum diet plan</li>
-      <li>Breastfeeding — is baby getting enough milk?</li>
-      <li>Your mental health &amp; postpartum depression support</li>
-    </ul>
-  </div>
-
-  <!-- BOTTOM APP CTA -->
-  <div class="cta bottom">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Get the complete Post-Delivery Guide free</h3>
-    <p>Recovery tips, feeding guidance &amp; baby tracking — all in one place.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+    <div class="cta-section">
+      <h3>Your full recovery guide is in the app</h3>
+      <p>Track healing, feeding &amp; baby growth — with doctor-backed daily guidance.</p>
+      <div class="cta-buttons">
+        <a class="cta-btn cta-btn-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Get it on Play Store</a>
+        <a class="cta-btn cta-btn-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
+      </div>
     </div>
+
+    <div class="disclaimer">
+      For general education only. Every recovery is different — always follow your obstetrician's advice, especially after complications, pain, fever, or heavy bleeding.
+    </div>
+
+    <div class="page-footer">
+      <a href="guides.html">&larr; All guides</a> &nbsp;&middot;&nbsp; <a href="index.html">MiGynae home</a><br>
+      &copy; 2026 MiGynae
+    </div>
+
   </div>
 
-  <!-- DISCLAIMER -->
-  <div class="disc">
-    For general education only. Every recovery is different — always follow your obstetrician's advice, especially after complications, pain, fever, or heavy bleeding.
-  </div>
-  <div class="foot"><a href="index.html" style="color:inherit;text-decoration:none;border-bottom:1px solid currentColor;padding-bottom:1px;">← Back to MiGynae</a> &nbsp;·&nbsp; © 2026 MiGynae</div>
-
-</div>
 </body>
 </html>

--- a/pre-labour-prep-guide.html
+++ b/pre-labour-prep-guide.html
@@ -3,283 +3,108 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Labour Prep - Quick Guide | MiGynae</title>
-    <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
-    <meta name="description" content="A quick labour-prep guide for a confident normal delivery: staying active, stepping it up from 28 weeks, questions to ask your doctor, and hospital warning signs.">
-    <link rel="canonical" href="https://migynaeapp.com/pre-labour-prep-guide.html">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://migynaeapp.com/pre-labour-prep-guide.html">
-    <meta property="og:title" content="Labour Prep - Quick Guide | MiGynae">
-    <meta property="og:description" content="A quick labour-prep guide for a confident normal delivery: staying active, stepping it up from 28 weeks, questions to ask your doctor, and hospital warning signs.">
-    <meta property="og:image" content="https://migynaeapp.com/images/logo.webp">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Labour Prep - Quick Guide | MiGynae">
-    <meta name="twitter:description" content="A quick labour-prep guide for a confident normal delivery: staying active, stepping it up from 28 weeks, questions to ask your doctor, and hospital warning signs.">
-<style>
-  :root{
-    --green:#2f4a3d;
-    --green-soft:#3f5e4f;
-    --cream:#faf6ee;
-    --card:#ffffff;
-    --ink:#2c2622;
-    --muted:#6b655d;
-    --line:#e7ded0;
-    --gold:#c8974a;
-    --rose:#b6524c;
-    --rose-bg:#fbeeed;
-    --ok:#3f7a5a;
-    --ok-bg:#eef5f0;
-    --serif:Georgia,'Times New Roman',serif;      /* → Lora */
-    --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; /* → DM Sans */
-  }
-  *{box-sizing:border-box;margin:0;padding:0;}
-  body{
-    background:#d9d3c7;
-    font-family:var(--sans);
-    color:var(--ink);
-    display:flex;justify-content:center;
-    padding:24px 12px;
-    -webkit-font-smoothing:antialiased;
-  }
-  .phone{
-    width:390px;max-width:100%;
-    background:var(--cream);
-    border-radius:28px;
-    overflow:hidden;
-    box-shadow:0 12px 40px rgba(0,0,0,.18);
-  }
-
-  /* ---- App CTA band ---- */
-  .cta{background:var(--green);color:#fff;padding:18px 20px 20px;}
-  .cta.bottom{padding:22px 20px 26px;}
-  .cta .flower{font-size:15px;}
-  .cta h3{font-family:var(--serif);font-weight:600;font-size:16px;line-height:1.35;margin:6px 0 4px;}
-  .cta p{font-size:12.5px;color:#d9e5df;line-height:1.5;margin-bottom:14px;}
-  .stores{display:flex;gap:8px;}
-  .store{
-    flex:1;display:flex;align-items:center;gap:8px;
-    background:#fff;color:var(--green);text-decoration:none;
-    padding:9px 10px;border-radius:11px;font-size:11px;font-weight:600;line-height:1.2;
-  }
-  .store .ico{font-size:16px;line-height:1;}
-  .store small{display:block;font-size:8.5px;font-weight:500;color:var(--muted);letter-spacing:.3px;}
-  .logo-badge{width:40px;height:40px;border-radius:50%;background:#fff;padding:4px;display:flex;align-items:center;justify-content:center;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,.12);}
-  .logo-badge img{width:100%;height:100%;object-fit:contain;border-radius:50%;}
-  .head .logo-badge{width:64px;height:64px;margin:0 auto 14px;}
-
-  /* ---- Header ---- */
-  .head{padding:22px 22px 6px;text-align:center;}
-  .kicker{font-size:10.5px;letter-spacing:1.6px;text-transform:uppercase;color:var(--gold);font-weight:700;margin-bottom:8px;}
-  .head h1{font-family:var(--serif);font-weight:600;font-size:23px;line-height:1.25;color:var(--green);}
-  .head .sub{font-size:13px;color:var(--muted);line-height:1.55;margin-top:10px;}
-
-  /* ---- Sections ---- */
-  .sec{padding:20px 22px 4px;}
-  .sec-title{font-family:var(--serif);font-size:17px;font-weight:600;color:var(--green);margin-bottom:12px;display:flex;align-items:center;gap:8px;}
-
-  .row{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;margin-bottom:10px;}
-  .tag{display:inline-block;font-size:10px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;padding:3px 9px;border-radius:20px;margin-bottom:7px;}
-  .tag.ok{background:var(--ok-bg);color:var(--ok);}
-  .tag.no{background:var(--rose-bg);color:var(--rose);}
-  .row p{font-size:13px;line-height:1.5;color:var(--ink);}
-  .row p b{color:var(--green);}
-  .note{font-size:11.5px;color:var(--muted);line-height:1.5;padding:2px 2px 0;}
-  .note b{color:var(--green);}
-
-  /* higher-risk callout */
-  .tag.hi{background:#fbf3e4;color:#a9781f;}
-  .callout{background:#fbf6ec;border:1px solid #efe0c4;border-radius:13px;padding:13px 15px;margin-top:10px;}
-  .callout .ct{font-size:11.5px;font-weight:700;letter-spacing:.4px;text-transform:uppercase;color:#a9781f;margin-bottom:6px;}
-  .callout p{font-size:12.5px;line-height:1.6;color:var(--ink);}
-  .callout p b{color:#8a6414;}
-
-  /* moves list */
-  .moves{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:6px 14px;}
-  .move{padding:12px 0;border-top:1px solid var(--line);}
-  .move:first-child{border-top:none;}
-  .move .m1{font-size:13.5px;font-weight:700;color:var(--green);}
-  .move .m2{font-size:12px;color:var(--muted);line-height:1.45;margin-top:2px;}
-
-  /* 28-week timeline */
-  .tl{position:relative;margin:0 0 12px 6px;}
-  .tl::before{content:"";position:absolute;left:5px;top:6px;bottom:16px;width:2px;background:var(--line);}
-  .tl-node{position:relative;padding:0 0 14px 24px;}
-  .tl-node:last-child{padding-bottom:2px;}
-  .tl-node::before{content:"";position:absolute;left:0;top:3px;width:12px;height:12px;border-radius:50%;background:var(--gold);border:2px solid var(--cream);box-shadow:0 0 0 1px var(--line);}
-  .tl-node.alt::before{background:var(--green);}
-  .tl-1{font-size:13px;font-weight:700;color:var(--green);}
-  .tl-2{font-size:12px;color:var(--muted);margin-top:1px;}
-
-  /* app blog chips */
-  .blogs{background:var(--card);border:1px solid var(--line);border-radius:13px;padding:13px 14px;}
-  .blogs-h{font-size:12px;color:var(--muted);line-height:1.45;margin-bottom:10px;}
-  .blog-chip{display:inline-block;background:var(--ok-bg);color:var(--green);font-size:12px;font-weight:600;padding:7px 12px;border-radius:20px;margin:0 6px 6px 0;border:1px solid #d9e7de;}
-
-  /* ask doctor - green numbered card */
-  .ask{margin:0 0 4px;background:var(--green);border-radius:15px;padding:16px 18px 14px;color:#fff;}
-  .ask h3{font-family:var(--serif);font-size:16px;font-weight:600;margin-bottom:4px;}
-  .ask .asub{font-size:11.5px;color:#cfe0d8;margin-bottom:12px;}
-  .ask ol{list-style:none;counter-reset:q;}
-  .ask li{
-    font-size:13px;line-height:1.45;padding:9px 0 9px 30px;position:relative;
-    border-top:1px solid rgba(255,255,255,.12);
-  }
-  .ask li:first-child{border-top:none;}
-  .ask li::before{
-    counter-increment:q;content:counter(q);
-    position:absolute;left:2px;top:9px;
-    width:18px;height:18px;border-radius:50%;
-    background:var(--gold);color:var(--green);
-    font-size:11px;font-weight:700;text-align:center;line-height:18px;
-  }
-
-  /* stop box */
-  .warn{background:var(--rose-bg);border:1px solid #f0d3d1;border-radius:15px;padding:16px 16px 6px;}
-  .warn .wt{font-family:var(--serif);font-size:16px;font-weight:600;color:var(--rose);margin-bottom:4px;}
-  .warn .ws{font-size:11.5px;color:#9a5450;margin-bottom:12px;}
-  .warn ul{list-style:none;}
-  .warn li{font-size:13px;line-height:1.45;color:var(--ink);padding:7px 0 7px 24px;position:relative;border-top:1px solid #f2dcda;}
-  .warn li:first-child{border-top:none;}
-  .warn li::before{content:"•";color:var(--rose);font-weight:700;position:absolute;left:8px;top:6px;font-size:15px;}
-
-  /* more in app */
-  .more{margin:18px 22px 4px;background:var(--green);border-radius:15px;padding:18px 18px 16px;color:#fff;}
-  .more h3{font-family:var(--serif);font-size:16px;font-weight:600;margin-bottom:4px;}
-  .more .msub{font-size:12px;color:#cfe0d8;margin-bottom:12px;}
-  .more ul{list-style:none;}
-  .more li{font-size:13px;line-height:1.4;padding:8px 0 8px 22px;position:relative;border-top:1px solid rgba(255,255,255,.12);}
-  .more li:first-child{border-top:none;}
-  .more li::before{content:"→";position:absolute;left:4px;color:var(--gold);font-weight:700;}
-
-  .disc{padding:16px 22px 4px;font-size:10.5px;line-height:1.5;color:var(--muted);text-align:center;}
-  .foot{padding:12px 22px 18px;text-align:center;font-size:10px;color:#a49d92;}
-  /* ===== Desktop / web view: full-width page with a centered content column ===== */
-  @media (min-width: 768px){
-    body{ padding:0; }
-    .phone{ width:100%; max-width:none; border-radius:0; box-shadow:none; }
-
-    /* coloured bands stay full-bleed; their content sits in a centered ~760px column */
-    .phone > *{
-      padding-left: max(24px, calc((100% - 760px) / 2));
-      padding-right: max(24px, calc((100% - 760px) / 2));
-    }
-    /* inset coloured cards become full-bleed bands too */
-    .more, .note{ margin-left:0; margin-right:0; border-radius:0; }
-    /* bottom CTA uses a two-class selector, so give it the column padding explicitly */
-    .cta.bottom{ padding-left: max(24px, calc((100% - 760px) / 2)); padding-right: max(24px, calc((100% - 760px) / 2)); }
-
-    /* larger, web-friendly typography */
-    .head{ padding-top:52px; }
-    .head .logo-badge{ width:80px; height:80px; }
-    .head h1{ font-size:34px; line-height:1.2; }
-    .head .sub{ font-size:16px; max-width:600px; margin-left:auto; margin-right:auto; }
-    .cta h3{ font-size:20px; }
-    .cta p{ font-size:14px; }
-    /* store buttons: natural badge size instead of stretching full width */
-    .stores{ gap:12px; justify-content:flex-start; }
-    .store{ flex:0 0 auto; width:210px; }
-    .sec-title{ font-size:22px; }
-    .row p, .row li, .tip .t2, .tip .t1, .block li, .block h2, .more li, .warn li,
-    .col li, .callout p, .soft p, .ask li, .mf-line, .note p, .blogs-h, .blog-chip, .chip{ font-size:15px; line-height:1.6; }
-    .disc{ font-size:12px; }
-  }
-
-</style>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<title>Labour Prep Guide | MiGynae</title>
+<meta name="description" content="A labour-prep guide for a confident normal delivery: staying active, stepping it up from 28 weeks, questions to ask your doctor, and hospital warning signs.">
+<link rel="canonical" href="https://migynaeapp.com/pre-labour-prep-guide.html">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://migynaeapp.com/pre-labour-prep-guide.html">
+<meta property="og:title" content="Labour Prep Guide | MiGynae">
+<meta property="og:description" content="A labour-prep guide for a confident normal delivery: staying active, stepping it up from 28 weeks, questions to ask your doctor, and hospital warning signs.">
+<meta property="og:image" content="https://migynaeapp.com/images/blog/labour-guide-banner.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Labour Prep Guide | MiGynae">
+<meta name="twitter:description" content="A labour-prep guide for a confident normal delivery: staying active, stepping it up from 28 weeks, questions to ask your doctor, and hospital warning signs.">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+<link rel="stylesheet" href="css/guide-page.css">
 </head>
 <body>
-<div class="phone">
 
-  <!-- TOP APP CTA -->
-  <div class="cta">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Prepare for a confident normal delivery - inside the MiGynae App</h3>
-    <p>Week-by-week labour prep, contraction &amp; kick tracking, doctor-backed guidance.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+  <div class="hero">
+    <div class="hero-inner">
+      <div class="hero-brand">Labour Preparation</div>
+      <h1>Prepare before labour begins</h1>
+      <p class="hero-tagline">If your pregnancy is low-risk, the smoothest normal deliveries start weeks before the first contraction. Save this.</p>
     </div>
   </div>
 
-  <!-- HEADER -->
-  <div class="head">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <div class="kicker">Labour Preparation</div>
-    <h1>Prepare before labour begins</h1>
-    <p class="sub">If your pregnancy is low-risk, the smoothest normal deliveries start weeks before the first contraction. Save this.</p>
+  <div class="download-bar">
+    <a class="dl-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Download on Play Store</a>
+    <a class="dl-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
   </div>
 
-  <!-- WHO IS THIS FOR -->
-  <div class="sec">
-    <div class="sec-title">First - can you aim for a normal delivery?</div>
-    <p class="note" style="margin:-4px 0 12px;">Not every pregnancy should, and that's completely okay. Your doctor decides this based on your risk.</p>
+  <div class="content">
 
-    <div class="row">
-      <span class="tag ok">Low-risk - usually a good candidate</span>
-      <p>One baby, head-down, full-term and growing well · placenta in a normal (not low-lying) position · no major medical complications · no bleeding or early cervical shortening · and your doctor has cleared you.</p>
+    <div class="intro-card">
+      A confident normal delivery is built <strong>before</strong> the first contraction — with gentle, consistent activity and the right guidance. Here is how to prepare.
     </div>
 
-    <div class="row">
-      <span class="tag hi">Higher-risk - a safe, planned path</span>
-      <p>If your pregnancy is higher-risk - for example a low-lying placenta, a breech or sideways baby, a previous caesarean or uterine surgery, twins, or a condition like severe pre-eclampsia or uncontrolled diabetes - a trial of normal labour may not be the safest route, and your doctor may plan a caesarean or a closely-watched birth. The active exercises here are meant for low-risk pregnancies - if you're higher-risk, follow the movement, diet and birth plan your <b>own</b> doctor gives you, and ask exactly what is safe for you.</p>
+    <div class="section">
+      <div class="section-header"><div class="section-number">1</div><h2>First — can you aim for a normal delivery?</h2></div>
+      <div class="section-body">
+        <p>Not every pregnancy should, and that is completely okay. Your doctor decides this based on your risk.</p>
+        <div class="card ok">
+          <div class="card-title"><i class="fas fa-check-circle"></i> Low-risk — usually a good candidate</div>
+          <p>One baby, head-down, full-term and growing well; placenta in a normal (not low-lying) position; no major medical complications; no bleeding or early cervical shortening; and your doctor has cleared you.</p>
+        </div>
+        <div class="card warn-soft">
+          <div class="card-title"><i class="fas fa-triangle-exclamation"></i> Higher-risk — a safe, planned path</div>
+          <p>If your pregnancy is higher-risk — for example a low-lying placenta, a breech or sideways baby, a previous caesarean or uterine surgery, twins, or a condition like severe pre-eclampsia or uncontrolled diabetes — a trial of normal labour may not be safest, and your doctor may plan a caesarean or a closely-watched birth. The active exercises here are meant for low-risk pregnancies — if you are higher-risk, follow the plan your <strong>own</strong> doctor gives you.</p>
+        </div>
+      </div>
     </div>
-  </div>
 
-  <!-- THE ONE RULE -->
-  <div class="sec">
-    <div class="sec-title">The one rule: stay active</div>
-
-    <div class="row">
-      <span class="tag ok">Do this</span>
-      <p>Keep moving - carry on daily routine, avoid unnecessary bed rest, and <b>don't panic at mild pulling pains</b>. A flexible, strong body handles labour better.</p>
+    <div class="section">
+      <div class="section-header"><div class="section-number">2</div><h2>The one rule: stay active</h2></div>
+      <div class="section-body">
+        <div class="card ok">
+          <div class="card-title"><i class="fas fa-check"></i> Do this</div>
+          <p>Keep moving — carry on daily routine, avoid unnecessary bed rest, and <strong>don't panic at mild pulling pains</strong>. A flexible, strong body handles labour better.</p>
+        </div>
+        <div class="card no">
+          <div class="card-title"><i class="fas fa-xmark"></i> The common mistake</div>
+          <p>Becoming over-cautious &rarr; stopping movement &rarr; the body stiffens &rarr; <strong>labour becomes harder</strong>.</p>
+        </div>
+      </div>
     </div>
 
-    <div class="row">
-      <span class="tag no">The common mistake</span>
-      <p>Becoming over-cautious → stopping movement → body stiffens → <b>labour becomes harder</b>.</p>
+    <div class="section">
+      <div class="section-header"><div class="section-number">3</div><h2>From 28 weeks, step it up</h2></div>
+      <div class="section-body">
+        <p>Stay active through pregnancy. From <span class="highlight">28 weeks</span>, your third-trimester preparation begins — and as your due date nears, gentle activity builds into active, labour-focused exercise.</p>
+        <div class="timeline">
+          <div class="tl-node"><div class="tl-1">28 weeks</div><div class="tl-2">Third-trimester activity begins</div></div>
+          <div class="tl-node"><div class="tl-1">Closer to labour</div><div class="tl-2">Active, labour-focused exercise</div></div>
+        </div>
+        <h3><i class="fas fa-book-open" style="color:var(--primary-dark)"></i> Three guides inside the app to prepare for a normal delivery</h3>
+        <div class="chips">
+          <span class="chip">3rd Trimester Exercise</span>
+          <span class="chip">Exercise for Normal Delivery</span>
+          <span class="chip">Foods for Normal Delivery</span>
+        </div>
+      </div>
     </div>
-  </div>
 
-  <!-- WHEN TO STEP IT UP -->
-  <div class="sec">
-    <div class="sec-title">From 28 weeks, step it up</div>
-    <div class="row" style="margin-bottom:14px;">
-      <p>Stay active through pregnancy. From <b>28 weeks</b>, your third-trimester preparation begins - and as your due date nears, gentle activity builds into <b>active, labour-focused exercise</b>.</p>
+    <div class="section">
+      <div class="section-header"><div class="section-number">4</div><h2>5 questions to ask your doctor</h2></div>
+      <div class="section-body">
+        <p>A prepared mother has a smoother journey.</p>
+        <ol class="q-list">
+          <li>Am I a candidate for a normal delivery?</li>
+          <li>What is my cervical status — length and dilation?</li>
+          <li>Can we wait for spontaneous labour if it's safe?</li>
+          <li>If my water leaks, can induction be tried first?</li>
+          <li>When is a C-section truly required?</li>
+        </ol>
+      </div>
     </div>
-    <div class="tl">
-      <div class="tl-node"><div class="tl-1">28 weeks</div><div class="tl-2">Third-trimester activity begins</div></div>
-      <div class="tl-node alt"><div class="tl-1">Closer to labour</div><div class="tl-2">Active, labour-focused exercise</div></div>
-    </div>
-    <div class="blogs">
-      <div class="blogs-h">📖 Three guides inside the MiGynae App to prepare for a normal delivery:</div>
-      <span class="blog-chip">3rd Trimester Exercise</span>
-      <span class="blog-chip">Exercise for Normal Delivery</span>
-      <span class="blog-chip">Foods for Normal Delivery</span>
-    </div>
-  </div>
 
-  <!-- ASK YOUR DOCTOR -->
-  <div class="sec">
-    <div class="ask">
-      <h3>5 questions to ask your doctor</h3>
-      <div class="asub">A prepared mother has a smoother journey.</div>
-      <ol>
-        <li>Am I a candidate for a normal delivery?</li>
-        <li>What is my cervical status - length and dilation?</li>
-        <li>Can we wait for spontaneous labour if it's safe?</li>
-        <li>If my water leaks, can induction be tried first?</li>
-        <li>When is a C-section truly required?</li>
-      </ol>
-    </div>
-  </div>
-
-  <!-- STOP SIGNS -->
-  <div class="sec">
-    <div class="warn">
-      <div class="wt">🏥 When to go to the hospital</div>
-      <div class="ws">Head in - or call your doctor - if you notice:</div>
+    <div class="warning-box">
+      <div class="warning-title"><i class="fas fa-hospital"></i> When to go to the hospital</div>
+      <p style="font-size:.9rem;margin-bottom:8px;color:var(--text-light)">Head in — or call your doctor — if you notice:</p>
       <ul>
         <li>Strong, regular labour pains that keep coming closer</li>
         <li>Your waters break, or fluid leaks</li>
@@ -288,37 +113,26 @@
         <li>Severe headache, blurred vision, or sudden swelling</li>
       </ul>
     </div>
-  </div>
 
-  <!-- MORE IN APP -->
-  <div class="more">
-    <h3>The full guide is in the app</h3>
-    <div class="msub">Plus more guides and tools inside:</div>
-    <ul>
-      <li>How to deal with labour pains - breathing, movement &amp; positions</li>
-      <li>3rd Trimester Diet - eating for an easier labour</li>
-      <li>When to consider an epidural</li>
-      <li>Contraction timer &amp; kick counter</li>
-    </ul>
-  </div>
-
-  <!-- BOTTOM APP CTA -->
-  <div class="cta bottom">
-    <div class="logo-badge"><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAQDAwMDAgQDAwMEBAQFBgoGBgUFBgwICQcKDgwPDg4MDQ0PERYTDxAVEQ0NExoTFRcYGRkZDxIbHRsYHRYYGRj/2wBDAQQEBAYFBgsGBgsYEA0QGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBj/wAARCACAAIADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD7+ooqve3ttp1hJeXcojhjGWY/560N21Y4xcnZbkssscELSzSLHGoyzMcAD1JriNZ+I1tAzQaNALlhx58uQn4Dqf0rk/Efii81+5KZaGyU/JAD1929T/KsGvLr453tT+8+xy7h2CSqYrV9v8zZvPFniG9cmTVJo1P8EP7sfpVNNX1aN96aneK3qJm/xqlRXA6k3q2fRQwlCC5YwSXojpLDxz4hsnHmXQu4+6XC5P8A30Oa77w/4v07XcQAG2u8ZMDn73+6e/8AOvHa0bfT7j/hH5dchkZPs9ykeV4IyMhgfUHH5100MVUi+6PLzDKMJVje3JJ6Jru9ro9zormvB/iP+3dKKXBH22DCy443jswHv3966WvYhNTipI+Fr0J0KjpVFqgoooqjEKKKKACiiigAryPxp4ibV9VNnbP/AKFbsQuDxI/Qt9Ow/wDr13PjXVzpPheTyn23FwfJjI6jI5P4DP6V49Xm4+tb92vmfWcN4BSbxU1tov1YUUUV5Z9gFFFWbDT7zU75LSxgaWVuw6AepPYe9NJt2RM5xgnKTskRW9vNdXUdtbxtJLIwVEXqTXoPiCwj8PfC1NMyHlmlQSMO7k7mP/juK3PDHhO10GHzpCs984w8uOFHovoPfvSeN9Jl1XwyRbsokt3EwDMFDAAgjJ6cH9K9OnhXTpyb+Jo+QxOcQxOLpQTtTjJO/d9/Q838LamdK8U2twWxE7eVL/utx+hwfwr2yvnvnHHBr1jUPGdnpfh2zlI+0Xs9ukiwg4xlRyx7D+dTgayjGSk9Ea8Q4GVWrTlSV5S0+46mWWOGJpZZFjReSzHAH41z15468OWjlBeNcMOot0Lj8+n615hq2uanrVwZL+5Z1zlYl4Rfov8AXrWdRUzB7QQ8LwzG18RLXsv8z1NfiRoRbBt75R6+Wp/9mrW0/wAW6BqTiODUI1kPSObMZ/XrXi1FZxx9RPVHTV4aw0l7jaf3n0JRXkHhzxjf6NMkFy73NieDGxy0Y9VP9P5V61bXMF5aR3VtIskUihkdehFejQrxrK63Plcwy2rgpWnqnszzH4jXxn8SRWQPyW0QJH+03J/QCuOrW8Tzm48Y6lITn9+VH0Xj+lZNeNXlzVJM+/y2iqWFpwXZfjqFFFbXhvw7ceINS8pSY7aPBmmx0HoPc/8A16zhBzfLHc6K9aFCDqVHZIboHh2+1+98uAeXAh/ezsOF9h6n2r1vR9EsNDsRbWUWM8vI3LSH1JrK17Ubbwf4Vji06BFdj5UCY4BxksfX19zXldzqeo3l0bm6vriSXOdxcjH0x0/CvRUqeE0teR8vKnic6TmpclNbLue9V5f488RxajONJs2V4IX3SSDIy4yCvuB/OqFt478QW2nm1M8Ux27VmlXLr+OefxrmiSSSSSTySe9TicYpx5YGuVZFLD1nVr622t+YUpJY5JJPTmkorzj6gKKKKACiiigArv8A4caw4nm0WZ8qQZoc9j/EP6/nXAVq+Grk2ni/Tpgcfvgh+jfKf51vh5uFRM8/NMOsRhZwfa69UVtXyfEN+T1+0Sf+hGqdafiOLyPF2pR4xi4cj8Tn+tZlZ1FaTR1YZqVGDXZfkWdPsbjU9ThsbVd0srbRnoPUn2A5r23SNKttG0mKxtV+VBlmPV27sfc1yHw30pUsp9ZkX55D5UWeyj7x/E8fhXb21zHdQ+ZGehKsD1VgcEH3zXq4KioR53uz4viDHSrVnRj8Mfz/AOBscr8RNOlu/Dkd3ECxtZN7Af3SME/hxXldfQToskZR1DKwwQRkEV5b4q8Fz6bLJfaXG01kfmaNeWh/xX37VnjcO2/aROvh/M4Qj9Wqu3Z/ocfRRRXln14UUUUAFFFFABRRRQAVc0pS2v2Kr1NxHj/voVTra8I2xuvGunoBkJJ5rfRQT/PFXSV5peZz4qahRnJ9E/yL3j+0Nv4yklxhbiNZB9QNp/lXL9Oa9L+JWnmXSrXUkXmBzG5/2W6fqB+deZt90/StsXDlqvzOLJK/tcHB9Vp93/APcPDVqLPwjp8AGMQKx+rDcf51Vt5jZePrmwJ/dXsAukHYSL8rfmAp/CtewAXS7dR0ESgf98iuf8Qn7N4z8OXa8bppLdj7MtevL3Yq3S3+R8NSftq01L7Sl9+/5o6iiignAya2OE5nWfA+j6q7TRqbO4bkyQgYY+69D+leTXUK299PbpKJVjkZBIBgNg4zXp/ivxlaWFlLY6bOs164K7ozlYfcn19BXldePjnT5rR36n3XD0cT7JyrN8vRP+tgooorhPogooooAKKKKACu++Gumlri71V1+VQIIz7nlv6VwkUUs9wkEKF5JGCIo7knAFe4aFpcej6Db2CYJRcuw/iY8k/nXdgaXNPmeyPnuIsWqWH9it5fkS6rYR6potzYSdJoyoPoex/A4rwmeGSCaWCZSsiEoynsRwa+gq8u+IWjG01hNVhT9zdcPjtIB/UfyNdOPpc0eddDyuG8Z7Oq6Etpbev/AAUeiaRKJtAspQc74Eb/AMdFYnjUeXa6Vef88NQiOfQHIqz4LuRc+CLE5yY1MR/4CSP5YpPGtu1x4JvSgJeILMv1Vgf5Zrok+alddjyqUfZY7kf81vxsdBUN1aW17bmC7gSaM9VcZFNsLlbzS7e7U5Esavn6jNWK23RwO8JeaOP1H4d6NcqWsWlsZOwQ70/75P8AQ1wuteF9W0Ml7mES2+f+PiLlfx7r+Ne1VXS5srwywRTwTlflkRWDY9iK5auEpz20Z7GDzzFUH7z5o+f+Z4HRXaeMfCUdhG2raSoNrn97EpyIvcf7Pt2+lcXXkVaUqcuWR9xg8ZTxdNVKf/DBRRRWZ1BRRXTeEfC0muXgubpSunxN8x6eaf7o9vU1dOm6kuWJhicTTw1N1ajskbfw/wDDhLDXrxMDkWyn8i/9B+Neh01ESONY41CqowFAwAPSnV71GkqUVFH5rjsZPF1nVn8vJBVDWdLh1jRZ7CfgSL8rf3GHQ/gav0Vo0mrM5oTlCSlF2aOJ+HzzWialol2uye2m3FfqMHHtkZ/GuyuIUubSW3kGUkQow9iMGsy500w+J7fWrZfmZDb3Kj+JD91vqCB+B9q16zpQ5Y8j6HVja6rVfbR0b1fk+v8Amcv4KuHj0y40O5P+kadKYSD3QklT/OuorkvEUE+i65F4qso2kjCiK+iXq0fZvqP6D3rp7S7t76yju7WVZIZF3Ky9xRSdvce6/IrGR52sRHaW/k+q/VeQXSSS2M0cTbZGRlU+hI4NeDpJdWMs0SSSQSEGGUKSpIzyp/EV79XNat4J0nVtYXUJWlhY8zJEQBL7n0PuKxxVCVWzjujuyXMaWEc41l7sv0MH4cWs0tjqRnUtZS7Y9jfdY4O79CAa4zWdPOla/d6eckRSEKT3U8j9CK9wtbS3srSO1tIVihjGFRRwBXlPxAVV8bSkdWhjJ+uCP6Vz4qioUYrqj08nx7xGPqSSspLb0tY5eiiu38MeBZbspfa0jRW/Vbc8NJ/veg9up9q4KVKVV2ifRYzG0sJDnqv/ADfoZnhbwnca7OLi43Q2Cn5n6GT/AGV/qa9btraC0tY7a2iWKKNdqIowAKdFFHDCsUSKiKMKqjAA9AKfXt0KEaSstz8/zHMqmNnzS0itl/XUKKKK3POCiiigArIuNTbSLrbqWfsTn5LvHEZP8Mnp7N07H316bJGksbRyIrowwVYZBHoRSd+hcHFP3ldCfu54eCskbj6hgf5iuVk0TVvD13Jd+Gis9o53SabK2AD6oe30/nVmTw5fac5l8M6ibRScmynHmQH6Dqv4U0a74js/k1LwxLNj/lrYyCQH/gJ5rGTT+JNPud9CMo39jJST3T0+9P8ARhF440pG8rVYbvTJhwUuYjj8CBzTU8XS6lqTWnh3TGv1T79y8nlxD8cGlfxXYTJ5d3oWre6SWZYVPa65EIhFp3hzVAueFFssK5+rECpUm9Ob8NTR0YRTl7F385e7+j/E07WbU2wLyygj94Z94/VRXmOuWl/4k8fX0em27TCNxEX6IgUYJJ6DnNenWj6jM3mXUEVqnaIP5jn6noPoM/WrFvbW9pD5VtCkSZJ2oMDJ6n61VWj7VKLehng8c8FUlUjFczVl2X+Zzfh3wTY6OUursrd3o5DkfJGf9kevuf0rqaKK0hCMFaKOTEYmpiJ+0qu7CiiirMAooooA/9k=" alt="MiGynae App logo"></div>
-    <h3>Get step-by-step labour prep free on the MiGynae App</h3>
-    <p>Track your pregnancy, contractions &amp; kick counts - all in one place.</p>
-    <div class="stores">
-      <a class="store" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><span class="ico">▶</span><span><small>GET IT ON</small>Play Store</span></a>
-      <a class="store" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><span class="ico"></span><span><small>DOWNLOAD ON</small>App Store</span></a>
+    <div class="cta-section">
+      <h3>The full guide is in the app</h3>
+      <p>Week-by-week labour prep, a 3rd-trimester diet, contraction timer &amp; kick counter — free during beta.</p>
+      <div class="cta-buttons">
+        <a class="cta-btn cta-btn-android" href="https://play.google.com/store/apps/details?id=com.mimedic.migynae" target="_blank" rel="noopener"><i class="fab fa-google-play"></i> Get it on Play Store</a>
+        <a class="cta-btn cta-btn-ios" href="https://apps.apple.com/in/app/migynae/id6748379521" target="_blank" rel="noopener"><i class="fab fa-apple"></i> Download on App Store</a>
+      </div>
     </div>
+
+    <div class="disclaimer">
+      Follow this only if your doctor has confirmed a low-risk pregnancy with no contraindications. Always consult your healthcare provider before starting any new exercise or diet.
+    </div>
+
+    <div class="page-footer">
+      <a href="guides.html">&larr; All guides</a> &nbsp;&middot;&nbsp; <a href="index.html">MiGynae home</a><br>
+      &copy; 2026 MiGynae
+    </div>
+
   </div>
 
-  <!-- DISCLAIMER -->
-  <div class="disc">
-    Follow this only if your doctor has confirmed a low-risk pregnancy with no contraindications. Always consult your healthcare provider before starting any new exercise or diet.
-  </div>
-  <div class="foot"><a href="index.html" style="color:inherit;text-decoration:none;border-bottom:1px solid currentColor;padding-bottom:1px;">← Back to MiGynae</a> &nbsp;·&nbsp; © 2026 MiGynae</div>
-
-</div>
 </body>
 </html>


### PR DESCRIPTION
Rebuild the 7 quick-guide pages (pre-labour, during-labour, epidural, caesarean, post-delivery, partner, family) in the existing guides' soft design system via a shared css/guide-page.css: gradient hero, numbered section cards, soft callouts, with the app-download prompt kept subtle at the top and bottom only. Lavender for the birth guides, pink for the recovery/support guides.

On the Guides hub, merge all 9 guides into one equal-tile grid (3 columns desktop, 2 tablet, 1 column mobile) with thumbnail cards — photo banners for the two existing guides, matching gradient banners for the seven — and remove the separate "Short, Shareable Reads" section.

All original guide content, store links, and internal links preserved.